### PR TITLE
fix: remove ssh_config matching host

### DIFF
--- a/modules/bastion/default.nix
+++ b/modules/bastion/default.nix
@@ -68,10 +68,6 @@ let
         HostName ${address}
         IdentitiesOnly yes
         ${optionalString (proxyJumps != [ ]) "ProxyJump ${concatStringsSep ", " translatedProxyJumps}"}
-
-      Match Host "${name}*,${shortName}*,${fullName}*,${address}*"
-        IdentitiesOnly yes
-        ${optionalString (proxyJumps != [ ]) "ProxyJump ${concatStringsSep ", " translatedProxyJumps}"}
     '';
 in
 {


### PR DESCRIPTION
Le match introduit trop d'erreur, je propose la suppression.