### PR TITLE
fix(vpn/wireguard): use the ambient PATH to run `wireguard-*`

### DIFF
--- a/modules/vpn/wireguard/default.nix
+++ b/modules/vpn/wireguard/default.nix
@@ -149,7 +149,7 @@ in
         groups = [ "operator" ];
         commands = [
           {
-            command = "/run/current-system/sw/bin/wireguard-${wg}";
+            command = "wireguard-${wg}";
             options = [ "NOPASSWD" ];
           }
         ];


### PR DESCRIPTION
As `wireguard-*` is a per-user package, it's not in /run/current-system/sw/bin.

We use a non-absolute path method.