### PR TITLE
modules/console: mkDefault all parameters

### DIFF
--- a/modules/console.nix
+++ b/modules/console.nix
@@ -1,15 +1,15 @@
 # SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>
 #
 # SPDX-License-Identifier: MIT
-
+{ lib, ... }:
 {
-  # Sécurix is not meant to be used outside of France.
-  time.timeZone = "Europe/Paris";
-  i18n.defaultLocale = "en_US.UTF-8";
+  # Sécurix is usually used in France.
+  time.timeZone = lib.mkDefault "Europe/Paris";
+  i18n.defaultLocale = lib.mkDefault "en_US.UTF-8";
   console = {
     # Let the kernel be smart.
     font = null;
-    keyMap = "fr";
+    keyMap = lib.mkDefault "fr";
   };
-  services.xserver.xkb.layout = "fr";
+  services.xserver.xkb.layout = lib.mkDefault "fr";
 }


### PR DESCRIPTION
This is meant to expand the useability of Securix beyond France.