### PR TITLE
Add a minimal test

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Sécurix repose sur NixOS avec un noyau Linux personnalisé conformément aux r�
 
 Les contributions sont les bienvenues ! Consultez les issues ouvertes et le guide de contribution pour participer.
 
+### Lancement des tests
+
+Les tests sont basés sur le framework de test NixOS. Ils permettent de
+lancer sécurix dans une VM puis exécuter des tests sur le comportement
+de cette VM.
+
+`nix-build -A tests`
+
 ## Licence
 
 Sécurix est distribué sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.

--- a/default.nix
+++ b/default.nix
@@ -42,9 +42,7 @@ let
       };
     };
   };
-in
-{
-  lib = import ./lib {
+  lib-securix = import ./lib {
     pkgs = pkgs';
     inherit
       lib
@@ -53,8 +51,15 @@ in
       sources
       ;
   };
+in
+{
+  lib = lib-securix;
   pkgs = pkgs';
   modules = ./modules;
+  tests = import ./tests {
+    pkgs = pkgs';
+    libSecurix = lib-securix;
+  };
   shell = pkgs'.mkShell {
     packages = [
       pkgs'.npins

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Antoine Eiche <aei.ext@hackcyom.com>
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, libSecurix }:
+{
+  minimal = import ./minimal.nix { inherit pkgs libSecurix; };
+}

--- a/tests/minimal.nix
+++ b/tests/minimal.nix
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2025 Antoine Eiche <aei.ext@hackcyom.com>
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, libSecurix }:
+let
+  terminal = libSecurix.mkTerminal {
+    name = "minimal";
+    userSpecificModule = { };
+    vpnProfiles = { };
+    modules = [
+      {
+        securix = {
+          graphical-interface.variant = "sway";
+          self = {
+            mainDisk = "/dev/nvme0n1";
+            machine = {
+              hardwareSKU = "x280";
+              serialNumber = "000000";
+            };
+          };
+        };
+      }
+    ];
+  };
+in
+pkgs.testers.nixosTest {
+  name = "minimal";
+  nodes = {
+    securix-unbranded-000000 = {
+      imports = terminal.modules;
+    };
+  };
+  testScript = ''
+    securix_unbranded_000000.wait_for_unit("default.target")
+    securix_unbranded_000000.succeed("cat /etc/os-release | grep securix")
+  '';
+}


### PR DESCRIPTION
This test boots a sécurix VM and just ensure the /etc/os-release file
contains securix.

The goal is to later add more useful tests. But this provides an
exemple to user on how to use sécurix.

```
[lewo@tilia:~/repos/securix]$ nix-build -A tests
checking outputs of '/nix/store/adv42p9dp87xb3crmk9snxpf6dyra1jj-vm-test-run-minimal.drv'...
Machine state will be reset. To keep it, pass --keep-vm-state
start all VLans
start vlan
running vlan (pid 9; ctl /build/vde1.ctl)
(finished: start all VLans, in 0.00 seconds)
Test will time out and terminate in 3600 seconds
run the VM test script
additionally exposed symbols:
    securix-unbranded-000000,
    vlan1,
    start_all, test_script, machines, vlans, driver, log, os, create_machine, subtest, run_tests, join_all, retry, serial_stdout_off, serial_stdout_on, polling_condition, Machine, t, debug
securix-unbranded-000000: waiting for unit default.target
securix-unbranded-000000: waiting for the VM to finish booting
securix-unbranded-000000: starting vm
...
...
...
securix-unbranded-000000 # [    9.953247] systemd[1]: Startup finished in 954ms (kernel) + 4.241s (initrd) + 4.754s (userspace) = 9.949s.
securix-unbranded-000000: (finished: waiting for unit default.target, in 14.68 seconds)
securix-unbranded-000000: must succeed: cat /etc/os-release | grep securix
securix-unbranded-000000 # [   10.054447] systemd-logind[562]: Watching system buttons on /dev/input/event2 (Power Button)
securix-unbranded-000000 # [   10.059725] systemd[1]: Stopped target Host and Network Name Lookups.
securix-unbranded-000000: (finished: must succeed: cat /etc/os-release | grep securix, in 0.08 seconds)
(finished: run the VM test script, in 14.76 seconds)
test script finished in 14.95s
cleanup
kill machine (pid 11)
qemu-system-x86_64: terminating on signal 15 from pid 8 (/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/bin/python3.13)
kill vlan (pid 9)
(finished: cleanup, in 0.02 seconds)
/nix/store/5m0p3r8wr28hzpj2s6r07aq9ipiv182m-vm-test-run-minimal
```
