### PR TITLE
fix: use mod+p for scratchpad commands

### DIFF
--- a/modules/graphical-interface/sway/sway-config.nix
+++ b/modules/graphical-interface/sway/sway-config.nix
@@ -201,11 +201,11 @@ in
           # You can send windows there and get them back later.
 
           # Move the currently focused window to the scratchpad
-          bindsym $mod+Shift+s move scratchpad
+          bindsym $mod+Shift+p move scratchpad
 
           # Show the next scratchpad window or hide the focused scratchpad window.
           # If there are multiple scratchpad windows, this command cycles through them.
-          bindsym $mod+s scratchpad show
+          bindsym $mod+p scratchpad show
       #
       # Resizing containers:
       #


### PR DESCRIPTION
Currently, the provided configuration fails on start because the defined mod+s shortcut collides with the default mod+s shortcut which allows to manipulate the layout.