### PR TITLE
fix : mkDefault for boot.initrd.systemd.enable as true

### DIFF
--- a/modules/bootloader.nix
+++ b/modules/bootloader.nix
@@ -4,7 +4,7 @@
 
 { pkgs, lib, ... }:
 {
-  boot.initrd.systemd.enable = true;
+  boot.initrd.systemd.enable = lib.mkForce true;
 
   boot.loader.systemd-boot.enable = lib.mkForce false;
 

--- a/modules/bootloader.nix
+++ b/modules/bootloader.nix
@@ -4,7 +4,7 @@
 
 { pkgs, lib, ... }:
 {
-  boot.initrd.systemd.enable = lib.mkForce true;
+  boot.initrd.systemd.enable = lib.mkDefault true;
 
   boot.loader.systemd-boot.enable = lib.mkForce false;
 


### PR DESCRIPTION
disko provoke a conflict on this var

securix use it as "true"
disko as "false"

Enforcing securix setting with mkForce