### PR TITLE
Make tools and firefox optional

### DIFF
--- a/modules/tools/default.nix
+++ b/modules/tools/default.nix
@@ -2,87 +2,100 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ pkgs, ... }:
 {
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.securix.tools;
+  inherit (lib) mkIf mkEnableOption types;
+in
+{
+  options.securix.tools.enable = mkEnableOption "default Securix tools" // {
+    default = true;
+  };
   imports = [ ./firefox.nix ];
+  config = mkIf cfg.enable {
+    programs.mtr.enable = true;
 
-  programs.mtr.enable = true;
-
-  environment.systemPackages = with pkgs; [
-    # Text editors
-    vscodium
-    vim
-    # TPM2
-    tpm2-tools
-    # A TPM-backed agent for SSH keys
-    ssh-tpm-agent
-    # VNC remoting
-    tigervnc
-    # Some good terminals.
-    alacritty
-    # Uncomment when NixOS 25.05 is used.
-    # ghostty
-    kitty
-    tmux # Multiplexer
-    screen # Multiplexer
-    # Scripting
-    python3
-    gum # TUI scripting
-    # PKI
-    certstrap # Certificate bootstrap for CAs
-    openssl # Generic purpose certificate tooling
-    step-ca # CA tooling
-    opensc # PKCS#11 tooling
-    # Misc
-    termdown # Time counter
-    fd # `find` alternative.
-    ripgrep # super fast `grep`
-    ripgrep-all # multi-format fast `grep`
-    pwgen # Password generator.
-    rofi-rbw-wayland # Rofi menu for rbw.
-    tree # Tree display
-    gnupg # PGP
-    connect # for using ssh with a proxy
-    jq # Lightweight and flexible command-line JSON processor
-    yq-go # Same as jq but for YAML
-    # Git, the full tooling.
-    gitFull
-    git-lfs
-    git-absorb
-    git-gr
-    lazygit
-    jujutsu
-    # Serial console work.
-    minicom
-    picocom
-    # To send files securly to another endpoint.
-    magic-wormhole-rs
-    # iPXE / PXE operations
-    pixiecore
-    # Unzipping
-    unzip
-    # To calculate things
-    libqalculate
-    # Troubleshooting
-    iperf3
-    tcpdump
-    dnsutils
-    conntrack-tools
-    pwru # Packet, where are you? - eBPF tooling
-    strace
-    gdb
-    # Network calculators
-    sipcalc
-    ipv6calc
-    # D-Bus debugging
-    d-spy
-    # Offline documentation
-    #linux-manual
-    glibcInfo
-    man-pages
-    man-pages-posix
-    # Browser
-    firefox
-    qrencode
-  ];
+    environment.systemPackages = with pkgs; [
+      # Text editors
+      vscodium
+      vim
+      # TPM2
+      tpm2-tools
+      # A TPM-backed agent for SSH keys
+      ssh-tpm-agent
+      # VNC remoting
+      tigervnc
+      # Some good terminals.
+      alacritty
+      # Uncomment when NixOS 25.05 is used.
+      # ghostty
+      kitty
+      tmux # Multiplexer
+      screen # Multiplexer
+      # Scripting
+      python3
+      gum # TUI scripting
+      # PKI
+      certstrap # Certificate bootstrap for CAs
+      openssl # Generic purpose certificate tooling
+      step-ca # CA tooling
+      opensc # PKCS#11 tooling
+      # Misc
+      termdown # Time counter
+      fd # `find` alternative.
+      ripgrep # super fast `grep`
+      ripgrep-all # multi-format fast `grep`
+      pwgen # Password generator.
+      rofi-rbw-wayland # Rofi menu for rbw.
+      tree # Tree display
+      gnupg # PGP
+      connect # for using ssh with a proxy
+      jq # Lightweight and flexible command-line JSON processor
+      yq-go # Same as jq but for YAML
+      # Git, the full tooling.
+      gitFull
+      git-lfs
+      git-absorb
+      git-gr
+      lazygit
+      jujutsu
+      # Serial console work.
+      minicom
+      picocom
+      # To send files securly to another endpoint.
+      magic-wormhole-rs
+      # iPXE / PXE operations
+      pixiecore
+      # Unzipping
+      unzip
+      # To calculate things
+      libqalculate
+      # Troubleshooting
+      iperf3
+      tcpdump
+      dnsutils
+      conntrack-tools
+      pwru # Packet, where are you? - eBPF tooling
+      strace
+      gdb
+      # Network calculators
+      sipcalc
+      ipv6calc
+      # D-Bus debugging
+      d-spy
+      # Offline documentation
+      #linux-manual
+      glibcInfo
+      man-pages
+      man-pages-posix
+      # Browser
+      firefox
+      qrencode
+    ];
+  };
 }

--- a/modules/tools/firefox.nix
+++ b/modules/tools/firefox.nix
@@ -10,7 +10,12 @@
   ...
 }:
 let
-  inherit (lib) listToAttrs mkOption;
+  inherit (lib)
+    listToAttrs
+    mkOption
+    mkEnableOption
+    mkIf
+    ;
   inherit (lib.types) attrsOf submodule str;
 
   cfg = config.securix.firefox;
@@ -43,32 +48,37 @@ let
   };
 in
 {
-  options.securix.firefox.bookmarks = mkOption {
-    type = attrsOf (attrsOf bookmarkType);
-    default = { };
-    example = ''
-      {
-        Productivity = {
-          Github = {
-            href = "https://github.com";
-            icon = "github.png";
+  options.securix.firefox = {
+    enable = mkEnableOption "Securix firefox distribution" // {
+      default = true;
+    };
+    bookmarks = mkOption {
+      type = attrsOf (attrsOf bookmarkType);
+      default = { };
+      example = ''
+        {
+          Productivity = {
+            Github = {
+              href = "https://github.com";
+              icon = "github.png";
+            };
           };
-        };
 
-        Entertainment = {
-          Youtube = {
-            href = "https://youtube.com";
-            icon = "si-youtube";
+          Entertainment = {
+            Youtube = {
+              href = "https://youtube.com";
+              icon = "si-youtube";
+            };
           };
-        };
-      }
-    '';
-    description = ''
-      Bookmarks to show to homepage and firefox bookmarks.
-    '';
+        }
+      '';
+      description = ''
+        Bookmarks to show to homepage and firefox bookmarks.
+      '';
+    };
   };
 
-  config = {
+  config = mkIf cfg.enable {
     # This spawns the dashboard on 127.0.0.1:8082.
     services.homepage-dashboard = {
       enable = true;


### PR DESCRIPTION
Dans certains cas, les utilisateurs souhaitent ne pas devoir embarquer la liste complete de logiciels inclus par Securix, pour des raisons de sécurité et de stockage.

Étant donné que ces logiciels sont ajoutés à la liste `systemPackages`, il n'est pas possible de les enlever, sans purger completement cette liste, qui est aussi utilisée par d'autres modules NixOS.

Les valeurs de ces options étant définies à `true` par défaut, il n'y a aucun breaking change.