### PR TITLE
nix: Point the nix path to a static value

### DIFF
--- a/modules/package-manager.nix
+++ b/modules/package-manager.nix
@@ -14,11 +14,12 @@ let
 in
 {
   config = {
+    environment.etc.nixpkgs.source = builtins.storePath pkgs.path;
     nix = {
       package = pkgs.lix;
       nixPath = [
         # Always point to the authorized sources.
-        "nixpkgs=${pkgs.path}"
+        "nixpkgs=/etc/nixpkgs"
       ];
     }
     // (lib.optionalAttrs proxyCfg.enable {


### PR DESCRIPTION
Otherwise updates are not taken into account when deploying without a reboot.