### PR TITLE
mkTerminal exposes the postInstallScript attribute

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -429,6 +429,7 @@ rec {
       modules,
       edition ? args.edition,
       compression ? "zstd -Xcompression-level 6",
+      postInstallScript ? "",
     }:
     let
       allModules = [
@@ -469,7 +470,7 @@ rec {
       ];
       installer = buildUSBInstallerISO {
         modules = allModules;
-        inherit compression;
+        inherit compression postInstallScript;
       };
       system = pkgs.nixos allModules;
     };


### PR DESCRIPTION
This allows downstreams to define their own `postInstallScript`.

Note this doesn't require any change to existing configurations.
