### PR TITLE
auditd: implement ANSSI R74 audit policy

### DIFF
--- a/modules/auditd.nix
+++ b/modules/auditd.nix
@@ -20,6 +20,14 @@ in
       type = types.str;
       description = "Email à qui envoyer les alertes d'espace disque";
     };
+
+    extraRules = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Additional audit rules to append to the default ANSSI-aligned ruleset.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -38,18 +46,72 @@ in
     security.audit = {
       enable = true;
       rules = [
-        # TODO:
-        # track audit itself accesses
-        # track shm accesses
-        # track mount/unmount
-        # track usb keys accesses
-        # track kernel module loading
-        # track kexec operations
-        # track network cards changes
-        # track thunderbolt changes
-        # This tracks only all execve for now, which is not that bad.
-        "-a exit,always -F arch=b64 -S execve"
-      ];
+        # ====================================================================
+        # ANSSI-aligned audit ruleset (R74 – Audit policy)
+        # See https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
+        # ====================================================================
+
+        # --- Track audit subsystem itself (tamper detection) ---
+        "-w /etc/audit/ -p wa -k audit-config"
+        "-w /etc/libaudit.conf -p wa -k audit-config"
+        "-w /etc/audisp/ -p wa -k audit-config"
+        "-w /var/log/audit/ -p wa -k audit-logs"
+
+        # --- Track process execution (all execve) ---
+        "-a always,exit -F arch=b64 -S execve -k exec"
+        "-a always,exit -F arch=b32 -S execve -k exec"
+
+        # --- Track privilege escalation (setuid/setgid family) ---
+        "-a always,exit -F arch=b64 -S setuid -S setgid -S setreuid -S setregid -S setresuid -S setresgid -k privilege-escalation"
+        "-a always,exit -F arch=b32 -S setuid -S setgid -S setreuid -S setregid -S setresuid -S setresgid -k privilege-escalation"
+
+        # --- Track mount/unmount operations ---
+        "-a always,exit -F arch=b64 -S mount -S umount2 -k mount"
+        "-a always,exit -F arch=b32 -S mount -S umount -S umount2 -k mount"
+
+        # --- Track kernel module loading/unloading ---
+        "-a always,exit -F arch=b64 -S init_module -S finit_module -S delete_module -k kernel-module"
+        "-a always,exit -F arch=b32 -S init_module -S finit_module -S delete_module -k kernel-module"
+        "-w /etc/modprobe.conf -p wa -k modprobe"
+        "-w /etc/modprobe.d/ -p wa -k modprobe"
+        "-w /etc/modules-load.d/ -p wa -k modprobe"
+
+        # --- Track kexec (live kernel replacement) ---
+        "-a always,exit -F arch=b64 -S kexec_load -S kexec_file_load -k kexec"
+
+        # --- Track shared memory operations ---
+        "-a always,exit -F arch=b64 -S shmget -S shmat -S shmdt -S shmctl -k shm"
+        "-a always,exit -F arch=b32 -S ipc -k shm"
+
+        # --- Track USB / removable devices (evil-maid vector) ---
+        "-w /sys/bus/usb/ -p wa -k usb-devices"
+
+        # --- Track Thunderbolt (DMA-capable bus) ---
+        "-w /sys/bus/thunderbolt/ -p wa -k thunderbolt"
+
+        # --- Track network interface / configuration changes ---
+        "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k hostname-change"
+        "-w /etc/hosts -p wa -k network-config"
+        "-w /etc/resolv.conf -p wa -k network-config"
+        "-w /etc/NetworkManager/ -p wa -k network-config"
+        "-w /etc/systemd/network/ -p wa -k network-config"
+        "-w /etc/nftables.conf -p wa -k firewall-config"
+
+        # --- Track PAM / authentication subsystem changes ---
+        "-w /etc/pam.d/ -p wa -k pam-config"
+        "-w /etc/security/ -p wa -k pam-config"
+        "-w /etc/u2f-mappings -p wa -k u2f-config"
+
+        # --- Track sudo / escalation configuration ---
+        "-w /etc/sudoers -p wa -k sudo-config"
+        "-w /etc/sudoers.d/ -p wa -k sudo-config"
+
+        # --- Track time changes (forensic timeline integrity) ---
+        "-a always,exit -F arch=b64 -S adjtimex -S settimeofday -S clock_settime -k time-change"
+        "-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S clock_settime -S stime -k time-change"
+        "-w /etc/localtime -p wa -k time-change"
+      ]
+      ++ cfg.extraRules;
     };
   };
 }


### PR DESCRIPTION
auditd: implement ANSSI R74 audit policy

Replaces the single execve rule + TODO block with a comprehensive
ruleset covering the 8 categories flagged in the TODO:
- audit subsystem tamper detection
- privilege escalation (setuid/setgid family)
- mount/umount operations
- kernel module load/unload + modprobe config
- kexec syscalls
- shared memory IPC
- USB + Thunderbolt bus events
- network config + hostname changes
- PAM + sudoers changes
- system time modifications

Adds securix.audit.extraRules for site-specific additions
(backwards-compatible, defaults to empty list).

Refs: https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux (R74)


---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
