### PR TITLE
anssi: R11 — pick yama ptrace_scope=2 (stricter than R11 minimum)

### DIFF
--- a/modules/anssi/kernel-options.nix
+++ b/modules/anssi/kernel-options.nix
@@ -175,12 +175,25 @@ in
     severity = "intermediary";
     category = "base";
 
-    config = _: { boot.kernel.sysctl."kernel.yama.ptrace_scope" = "1"; };
+    # ptrace_scope values:
+    #   0 — classic permissions (any process can attach to its children)
+    #   1 — only ancestor processes can attach (Linux default, ANSSI R11 minimum)
+    #   2 — only CAP_SYS_PTRACE can attach (admin-only)
+    #   3 — ptrace disabled entirely (breaks debuggers / crash tools)
+    # ANSSI R11 requires ≥ 1. Sécurix picks 2 as a stricter default suited to
+    # an admin workstation: scope=1 still lets an unprivileged user dump
+    # secrets from their own agent processes (ssh-agent, gpg-agent,
+    # yubikey-agent, charon-nm), which defeats the point of hardware-backed
+    # keys. scope=2 preserves debugger workflows for admins (who can acquire
+    # CAP_SYS_PTRACE via sudo) while closing that gap. scope=3 is rejected
+    # because it breaks `strace`, `gdb` and `coredumpctl` entirely with no
+    # material security gain over scope=2.
+    config = _: { boot.kernel.sysctl."kernel.yama.ptrace_scope" = "2"; };
 
     checkScript =
       pkgs:
       pkgs.writeShellScript "check-R11" ''
-        ${mkSysctlChecker pkgs.lib { "kernel.yama.ptrace_scope" = 1; }}
+        ${mkSysctlChecker pkgs.lib { "kernel.yama.ptrace_scope" = 2; }}
       '';
   };
 


### PR DESCRIPTION
anssi: R11 — pick yama ptrace_scope=2 (stricter than R11 minimum)

ANSSI R11 requires `kernel.yama.ptrace_scope ≥ 1` — the Linux
default. This PR moves Sécurix to `2`, which is stricter than the
minimum, and argues why it's the right default for an admin
workstation.

## Why stricter than R11's "at least 1"

scope=1 lets an unprivileged user ptrace their *own* processes. On
a Sécurix workstation those processes include `ssh-agent`,
`gpg-agent`, `yubikey-agent`, `charon-nm` — every credential
holder. Any user-space compromise (browser RCE, malicious shell
script) can then attach and dump the in-memory keys, sidestepping
the hardware-backed-key posture Sécurix is built on.

scope=2 requires `CAP_SYS_PTRACE`, which admins can acquire via
`sudo strace` or `sudo gdb`. Regular debugging workflows are
preserved; opportunistic process-memory dumping by the same user
is closed.

scope=3 (disable ptrace entirely) was considered and rejected:
breaks `strace`, `gdb`, `coredumpctl`, `systemd-coredump` with no
security gain over scope=2 on a system that already uses SSH keys
sealed in hardware.

## Validation

Built `tests.full` with the change:

```
$ grep yama result/etc/sysctl.d/*.conf
kernel.yama.ptrace_scope=2

$ sysctl -w kernel.yama.ptrace_scope=2  # live
$ as user, strace -p <ssh-agent pid>
strace: attach: ptrace(PTRACE_SEIZE, …): Operation not permitted
```

## Refs

- ANSSI v2.0 R11 — *Activer et configurer le LSM Yama* (guide mandates
  `kernel.yama.ptrace_scope ≥ 1`)
- Linux kernel docs — `Documentation/admin-guide/LSM/Yama.rst`
- Prior art: Chrome OS, Ubuntu default since 14.04 used `scope=1`;
  a number of hardened distros (Qubes, GrapheneOS, Alpine hardened)
  raise to `2`.

---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
