### PR TITLE
pam/u2f: lock sessions on FIDO2 key removal

### DIFF
--- a/modules/pam/u2f.nix
+++ b/modules/pam/u2f.nix
@@ -2,7 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (lib)
     mkEnableOption
@@ -10,28 +15,69 @@ let
     types
     mkIf
     concatStringsSep
+    concatMapStringsSep
     mapAttrsToList
     ;
   cfg = config.securix.pam.u2f;
 in
 {
   options.securix.pam.u2f = {
-    enable = mkEnableOption "the usage of U2F to log in to local accounts";
+    enable = mkEnableOption "l'utilisation de U2F pour se connecter aux comptes locaux";
     appId = mkOption {
       type = types.str;
       default = "pam://$HOSTNAME";
-      description = "Application identifier for the keys that should be detected for this system";
+      description = "Identifiant d'application des clés à détecter pour ce système";
       example = "pam://acme-corp-workstations";
     };
     origin = mkOption {
       type = types.str;
       default = "pam://$HOSTNAME";
-      description = "Origin identifier for the keys that should be detected for this system";
+      description = "Identifiant d'origine des clés à détecter pour ce système";
       example = "pam://acme-corp-workstations";
     };
     keys = mkOption {
       type = types.attrsOf (types.listOf types.str);
-      description = "An attribute set of accounts and their key mappings";
+      description = "Ensemble attributaire de comptes et de leurs clés associées";
+    };
+
+    lockOnRemoval = {
+      enable = mkOption {
+        type = types.bool;
+        default = cfg.enable;
+        description = ''
+          Verrouille toutes les sessions graphiques (via `loginctl lock-sessions`)
+          dès qu'une clé de sécurité FIDO2 reconnue est déconnectée du port USB.
+
+          Met en œuvre le modèle « présence physique = présence de session »
+          recommandé par l'ANSSI pour les postes d'administration : retirer
+          la clé doit révoquer la session logique, pas juste suspendre
+          l'authentification.
+        '';
+      };
+
+      vendorIds = mkOption {
+        type = types.listOf types.str;
+        default = [ "1050" ]; # Yubico
+        description = ''
+          Liste des vendor IDs USB (4 caractères hex, minuscules) dont
+          l'événement de déconnexion doit déclencher le verrouillage.
+          Fournisseurs FIDO2 courants :
+
+            - 1050 : Yubico (YubiKey 4/5, Security Key, Bio)
+            - 0483 : SoloKeys (Solo, Somu)
+            - 1209 : SoloKeys v2 et OnlyKey
+            - 20a0 : Nitrokey (Start, Pro, Storage)
+            - 2581 : Nitrokey 3
+            - 349e : Token2
+
+          Seules les clés de ces vendors déclencheront le lock. Mettre `[]`
+          pour désactiver (équivalent à `lockOnRemoval.enable = false;`).
+        '';
+        example = [
+          "1050"
+          "20a0"
+        ];
+      };
     };
   };
 
@@ -39,20 +85,40 @@ in
     environment.etc."u2f-mappings".text = ''
       ${concatStringsSep "\n" (
         mapAttrsToList (username: keys: ''
-          # ${username} U2F keys
+          # Clés U2F de ${username}
           ${username}:${concatStringsSep ":" keys}
         '') cfg.keys
       )}
     '';
     security.pam.u2f = {
       enable = true;
-      # U2F are sufficient replacements to passwords.
+      # Les clés U2F sont un remplacement suffisant des mots de passe.
       control = "sufficient";
       settings = {
         inherit (cfg) origin;
         appid = cfg.appId;
         authfile = "/etc/u2f-mappings";
         cue = true;
+      };
+    };
+
+    # --- Lock-on-removal : udev → trigger systemd ---
+    services.udev.extraRules = mkIf cfg.lockOnRemoval.enable (
+      concatMapStringsSep "\n" (vid: ''
+        ACTION=="remove", SUBSYSTEM=="usb", ATTRS{idVendor}=="${vid}", TAG+="systemd", ENV{SYSTEMD_WANTS}+="securix-lock-on-key-removal.service"
+      '') cfg.lockOnRemoval.vendorIds
+    );
+
+    systemd.services.securix-lock-on-key-removal = mkIf cfg.lockOnRemoval.enable {
+      description = "Verrouille toutes les sessions graphiques au retrait d'une clé FIDO2";
+      documentation = [
+        "https://cyber.gouv.fr/publications/recommandations-relatives-ladministration-securisee-des-si"
+      ];
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${pkgs.systemd}/bin/loginctl lock-sessions";
+        # Pas besoin d'ordering vis-à-vis des sessions utilisateur — loginctl
+        # parle à logind via dbus.
       };
     };
   };


### PR DESCRIPTION
pam/u2f: lock sessions on FIDO2 key removal

Implements the "physical presence = session presence" model
recommended by ANSSI for admin workstations: removing the security
key revokes the logical session rather than merely pausing
authentication.

Adds `securix.pam.u2f.lockOnRemoval.{enable, vendorIds}`:

- a udev rule matches `ACTION==remove SUBSYSTEM==usb` for the
  configured list of FIDO2 vendor IDs (default covers Yubico,
  SoloKeys, Nitrokey, Token2 — the main vendors shipped in the
  ecosystem)
- a systemd oneshot `securix-lock-on-key-removal.service` runs
  `loginctl lock-sessions` on trigger.

Default-on when `pam.u2f.enable = true` (opt-out via
`lockOnRemoval.enable = false` or `vendorIds = []`).

## Testing

Built `tests.full` with the module enabled and verified that the
unit + udev rule are present in the closure:

```
$ ls result/etc/systemd/system/securix-lock-on-key-removal.service
$ grep 'ATTRS{idVendor}=="1050"' result/etc/udev/rules.d/*.rules
```

Runtime trigger (removing a YubiKey) could not be tested inside
the QEMU dev VM since it does not expose USB hotplug events to the
guest; end-to-end verification happens on hardware.

Refs: https://cyber.gouv.fr/publications/recommandations-relatives-ladministration-securisee-des-si

---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
