### PR TITLE
pam/faillock: add brute-force protection module (ANSSI R52/R64)

### DIFF
--- a/modules/pam/default.nix
+++ b/modules/pam/default.nix
@@ -2,4 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ imports = [ ./u2f.nix ]; }
+{
+  imports = [
+    ./u2f.nix
+    ./faillock.nix
+  ];
+}

--- a/modules/pam/faillock.nix
+++ b/modules/pam/faillock.nix
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# ANSSI R52 / R64 — Protection contre les attaques par force brute sur
+# l'authentification locale (login, su, sudo, sshd, screen lock).
+#
+# pam_faillock tient un compteur par compte dans /var/run/faillock/ ;
+# au-delà de `deny` échecs consécutifs, l'authentification est refusée
+# pendant `unlockTime` secondes. Les administrateurs peuvent débloquer
+# manuellement avec `faillock --reset <user>`.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    genAttrs
+    ;
+  cfg = config.securix.pam.faillock;
+
+  commonArgs = [
+    "silent"
+    "deny=${toString cfg.deny}"
+    "unlock_time=${toString cfg.unlockTime}"
+  ] ++ lib.optional cfg.auditLog "audit";
+
+  faillockModule = "${pkgs.linux-pam}/lib/security/pam_faillock.so";
+in
+{
+  options.securix.pam.faillock = {
+    enable = mkEnableOption "account lockout via pam_faillock";
+
+    deny = mkOption {
+      type = types.ints.positive;
+      default = 5;
+      description = ''
+        Number of consecutive failed authentication attempts before the
+        account is locked. ANSSI recommends a value between 3 and 10
+        depending on the operational context.
+      '';
+    };
+
+    unlockTime = mkOption {
+      type = types.ints.unsigned;
+      default = 900; # 15 minutes
+      description = ''
+        Seconds after the last failed attempt before the lockout expires
+        automatically. Set to 0 to require manual unlock by the administrator
+        (`faillock --reset <user>`).
+      '';
+    };
+
+    auditLog = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Emit failed/successful authentication events to auditd (recommended
+        when `securix.audit.enable = true`).
+      '';
+    };
+
+    services = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "login"
+        "sshd"
+        "sudo"
+        "su"
+        "swaylock"
+      ];
+      description = ''
+        PAM services to wire pam_faillock into. Each listed service will
+        run `pam_faillock preauth` early in its auth stack and
+        `pam_faillock authfail` at the end to update the counter.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    security.pam.services = genAttrs cfg.services (_: {
+      rules.auth = {
+        faillock-preauth = {
+          # Runs before any other auth module. If the account is already
+          # locked, this denies immediately and stops the stack.
+          order = 9000;
+          control = "required";
+          modulePath = faillockModule;
+          args = [ "preauth" ] ++ commonArgs;
+        };
+
+        faillock-authfail = {
+          # Runs after all auth modules (incl. pam_deny at order 12400).
+          # Increments the tally for this user and kills the stack.
+          order = 13000;
+          control = "[default=die]";
+          modulePath = faillockModule;
+          args = [ "authfail" ] ++ commonArgs;
+        };
+      };
+
+      rules.account = {
+        # The account phase must also consult faillock so that a locked
+        # user cannot fall through to the unix account module.
+        faillock = {
+          order = 10500;
+          control = "required";
+          modulePath = faillockModule;
+        };
+      };
+    });
+  };
+}


### PR DESCRIPTION
Introduces securix.pam.faillock with an options-based interface:

  securix.pam.faillock = {
    enable = true;
    deny = 5;                              # consecutive failures
    unlockTime = 900;                      # 15-min automatic unlock
    auditLog = true;                       # emit audit events
    services = [ "login" "sshd" "sudo" "su" "swaylock" ];
  };

The module injects three rules into each listed service:

  order 9000  auth required      pam_faillock preauth silent deny=... unlock_time=... [audit]
  order 10500 account required   pam_faillock
  order 13000 auth [default=die] pam_faillock authfail silent deny=... unlock_time=... [audit]

Tally files live in /var/run/faillock/<user>. Admins unlock manually
with `faillock --reset <user>`. The account phase entry also denies
further authentication of a locked user (prevents falling through to
the unix account module).

Default service list covers the main ingress points on a Sécurix
workstation. Screenlock (swaylock) is included because password
fallback there is as sensitive as login.

Refs: ANSSI R52 (verrouillage sur échecs répétés), R64 (politique
de mot de passe).