### PR TITLE
pam: add brute-force (faillock) and keystroke audit (tty-audit) modules

### DIFF
--- a/modules/pam/default.nix
+++ b/modules/pam/default.nix
@@ -6,5 +6,6 @@
   imports = [
     ./u2f.nix
     ./faillock.nix
+    ./tty-audit.nix
   ];
 }

--- a/modules/pam/default.nix
+++ b/modules/pam/default.nix
@@ -2,4 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ imports = [ ./u2f.nix ]; }
+{
+  imports = [
+    ./u2f.nix
+    ./faillock.nix
+  ];
+}

--- a/modules/pam/faillock.nix
+++ b/modules/pam/faillock.nix
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# ANSSI R52 / R64 — brute-force protection for local authentication
+# (login, su, sudo, sshd, screen lock).
+#
+# pam_faillock keeps a per-account counter in /var/run/faillock/;
+# after `deny` consecutive failures authentication is refused for
+# `unlockTime` seconds. An admin can unlock manually with
+# `faillock --reset <user>`.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    genAttrs
+    ;
+  cfg = config.securix.pam.faillock;
+
+  commonArgs = [
+    "silent"
+    "deny=${toString cfg.deny}"
+    "unlock_time=${toString cfg.unlockTime}"
+  ]
+  ++ lib.optional cfg.auditLog "audit";
+
+  faillockModule = "${pkgs.linux-pam}/lib/security/pam_faillock.so";
+in
+{
+  options.securix.pam.faillock = {
+    enable = mkEnableOption "account lockout via pam_faillock";
+
+    deny = mkOption {
+      type = types.ints.positive;
+      default = 5;
+      description = ''
+        Number of consecutive authentication failures before the
+        account is locked. ANSSI recommends a value between 3 and
+        10 depending on the operational context.
+      '';
+    };
+
+    unlockTime = mkOption {
+      type = types.ints.unsigned;
+      default = 900; # 15 minutes
+      description = ''
+        Seconds after the last failure before the lock expires
+        automatically. Set to 0 to require manual admin unlock
+        (`faillock --reset <user>`).
+      '';
+    };
+
+    auditLog = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Emit success / failure authentication events to auditd
+        (recommended when `securix.audit.enable = true`).
+      '';
+    };
+
+    services = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "login"
+        "sshd"
+        "sudo"
+        "su"
+        "swaylock"
+      ];
+      description = ''
+        PAM services to wire pam_faillock into. Each listed service
+        runs `pam_faillock preauth` early in its `auth` stack and
+        `pam_faillock authfail` at the end to update the counter.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    security.pam.services = genAttrs cfg.services (_: {
+      rules.auth = {
+        faillock-preauth = {
+          # Runs before any other auth module. If the account is
+          # already locked, denies immediately and stops the stack.
+          order = 9000;
+          control = "required";
+          modulePath = faillockModule;
+          args = [ "preauth" ] ++ commonArgs;
+        };
+
+        faillock-authfail = {
+          # Runs after all auth modules (incl. pam_deny at 12400).
+          # Increments the counter for this user and kills the stack.
+          order = 13000;
+          control = "[default=die]";
+          modulePath = faillockModule;
+          args = [ "authfail" ] ++ commonArgs;
+        };
+      };
+
+      rules.account = {
+        # The account phase also consults faillock so that a locked
+        # user cannot fall through to the unix account module.
+        faillock = {
+          order = 10500;
+          control = "required";
+          modulePath = faillockModule;
+        };
+      };
+    });
+  };
+}

--- a/modules/pam/tty-audit.nix
+++ b/modules/pam/tty-audit.nix
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# ANSSI R74 — log interactive administrator activity.
+#
+# pam_tty_audit(8) tells the kernel to record every keystroke
+# typed into a TTY after authentication, for users listed in
+# `enable=`. Events are routed to auditd (which must be active
+# via `securix.audit.enable = true`).
+#
+# Complements the R74 `-a always,exit -F arch=b64 -S execve` rule
+# in `securix.audit`: `execve` traces *which commands* were
+# launched, `pam_tty_audit` traces *what was typed* (including
+# commands typed in an interactive shell before they are
+# executed, vim edits, passwords entered into applications, etc.).
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    genAttrs
+    concatStringsSep
+    optional
+    ;
+  cfg = config.securix.pam.ttyAudit;
+
+  ttyAuditModule = "${pkgs.linux-pam}/lib/security/pam_tty_audit.so";
+
+  args =
+    optional (cfg.enableFor != [ ]) "enable=${concatStringsSep "," cfg.enableFor}"
+    ++ optional (cfg.disableFor != [ ]) "disable=${concatStringsSep "," cfg.disableFor}"
+    ++ optional cfg.logPassword "log_passwd";
+in
+{
+  options.securix.pam.ttyAudit = {
+    enable = mkEnableOption "keystroke auditing via pam_tty_audit";
+
+    enableFor = mkOption {
+      type = types.listOf types.str;
+      default = [ "*" ];
+      description = ''
+        User names whose TTY input should be audited. Use
+        `[ "*" ]` (default) to audit everyone — recommended for
+        admin workstations per ANSSI. Use `[ "root" ]` to audit
+        only root sessions, or a targeted list.
+      '';
+      example = [
+        "root"
+        "alice"
+      ];
+    };
+
+    disableFor = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        User names explicitly excluded from TTY auditing, even
+        if they match `enableFor`. Useful to carve out service
+        accounts.
+      '';
+      example = [ "nixbld" ];
+    };
+
+    logPassword = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        When true, also record input during password prompts
+        (terminal echo-off mode). **Strongly discouraged** —
+        audit logs would contain plaintext passwords, defeating
+        the purpose of hashing them in /etc/shadow. Kept here
+        for explicit opt-in only.
+      '';
+    };
+
+    services = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "login"
+        "sshd"
+        "su"
+        "sudo"
+      ];
+      description = ''
+        PAM services into which `pam_tty_audit` is wired. Only
+        services that allocate a TTY should be listed (login,
+        sshd, su, sudo). Adding it to non-TTY services like
+        swaylock or polkit is a no-op.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Require auditd, otherwise pam_tty_audit events are discarded.
+    assertions = [
+      {
+        assertion = config.security.auditd.enable or config.securix.audit.enable or false;
+        message = ''
+          `securix.pam.ttyAudit.enable = true` requires auditd to
+          be enabled, otherwise pam_tty_audit events are discarded.
+          Set either `securix.audit.enable = true` (recommended) or
+          `security.auditd.enable = true`.
+        '';
+      }
+    ];
+
+    security.pam.services = genAttrs cfg.services (_: {
+      rules.session.tty-audit = {
+        # Runs in the session phase, after successful auth. The
+        # kernel starts recording TTY input from this point on.
+        order = 10500;
+        control = "required";
+        modulePath = ttyAuditModule;
+        inherit args;
+      };
+    });
+  };
+}


### PR DESCRIPTION
pam/tty-audit: add keystroke auditing module (ANSSI R74)

Adds `securix.pam.ttyAudit` — a PAM session-phase wrapper around
`pam_tty_audit(8)` that instructs the kernel to log every
keystroke typed into a TTY after authentication, routing the
events to auditd.

Complements the `execve`-tracing rule shipped in
`modules/auditd.nix`:

- `execve` audits *which commands* were launched
- `pam_tty_audit` audits *what was typed* — including commands
  typed in a shell, text written in vim, interactive REPLs, etc.

Closes the "shell-activity" gap flagged by ANSSI R74 for
administration workstations.

## Options

```nix
securix.pam.ttyAudit = {
  enable = true;
  enableFor = [ "*" ];                       # default: everyone
  disableFor = [];                           # targeted opt-out
  logPassword = false;                       # never log echo-off input
  services = [ "login" "sshd" "su" "sudo" ]; # TTY-allocating only
};
```

Asserts auditd is enabled (`securix.audit.enable` or
`security.auditd.enable`) — without it, pam_tty_audit events go
nowhere. `logPassword` is explicitly opt-in and strongly
discouraged.

Injects one `session required pam_tty_audit.so enable=*` rule per
listed service at order 10500.

## Refs

- ANSSI v2.0 R74 — *politique d'audit*

pam/faillock: add brute-force protection module (ANSSI R52/R64)

Introduces `securix.pam.faillock` with an options-based interface:

```nix
securix.pam.faillock = {
  enable = true;
  deny = 5;                              # consecutive failures
  unlockTime = 900;                      # 15-minute auto-unlock

---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
