### PR TITLE
anssi: implement R66 — NSS hardening

### DIFF
--- a/modules/anssi/nss-hardening.nix
+++ b/modules/anssi/nss-hardening.nix
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# ANSSI R66 — Restreindre les mécanismes de résolution de noms.
+#
+# NSS (Name Service Switch) dispatches all lookups for hosts, users,
+# groups, services, etc. through a list of pluggable backends. Every
+# backend in `/etc/nsswitch.conf` is a potential attack surface:
+#
+#   * `mdns4_minimal` / `mdns6_minimal` (Avahi) — passive mDNS queries
+#     leak local interests on the LAN and open DNS-spoofing paths via
+#     link-local resolution.
+#   * `nis`, `nisplus`, `wins`, `winbind` — legacy auth/name protocols
+#     with known weaknesses; none should appear on a modern Sécurix
+#     workstation.
+#   * `mymachines` (systemd-machined) — container name resolution, not
+#     needed on an end-user workstation.
+#   * `myhostname` (nss-myhostname) — translates the local hostname
+#     to an IP. Useful inside Docker, dead-weight on a workstation
+#     where `/etc/hosts` already maps the hostname.
+#
+# After this rule, `/etc/nsswitch.conf` contains only `files + dns`
+# on the `hosts:` line (plus `files [success=merge] systemd` on
+# passwd/group which stay for systemd-sysusers integration).
+{
+  R66 = {
+    name = "R66_NSSHardening";
+    anssiRef = "R66 – Restreindre les mécanismes de résolution de noms";
+    description = ''
+      Disable non-essential NSS backends (mDNS, NIS, WINS, mymachines,
+      myhostname) so that name resolution only traverses the explicitly
+      trusted paths: /etc/hosts (files) and DNS.
+    '';
+    severity = "intermediary";
+    category = "base";
+    tags = [ "nss-hardening" ];
+
+    config =
+      { lib, ... }:
+      {
+        # Prevent Avahi from injecting mDNS backends into nsswitch even
+        # if services.avahi.enable becomes true later (defensive).
+        services.avahi.nssmdns4 = lib.mkForce false;
+        services.avahi.nssmdns6 = lib.mkForce false;
+
+        # Strictly limit the `hosts:` lookup chain. Sites that need
+        # systemd-resolved (DNSSEC) can add `"resolve"` via a lower-
+        # priority override (mkOverride 90) or disable this rule.
+        system.nssDatabases.hosts = lib.mkForce [
+          "files"
+          "dns"
+        ];
+      };
+
+    checkScript =
+      pkgs:
+      pkgs.writeShellScript "check-R66" ''
+        # Fail if any forbidden NSS backend appears anywhere in
+        # /etc/nsswitch.conf. Uses -w for word-boundary so "mdns"
+        # catches "mdns4_minimal" / "mdns6_minimal" / "mdns" equally.
+        status=0
+        for bad in mdns mdns4 mdns4_minimal mdns6 mdns6_minimal nis nisplus wins winbind mymachines myhostname; do
+          if ${pkgs.gnugrep}/bin/grep -qwE "$bad" /etc/nsswitch.conf; then
+            echo "FAIL: /etc/nsswitch.conf contains forbidden backend '$bad'"
+            status=1
+          fi
+        done
+        if [ $status -eq 0 ]; then
+          echo "PASS: nsswitch.conf is restricted to files+dns+systemd"
+        fi
+        exit $status
+      '';
+  };
+}

--- a/modules/anssi/ruleset.nix
+++ b/modules/anssi/ruleset.nix
@@ -17,7 +17,7 @@ loadRules [
   # ./journaling.nix
   # ./runtime-minimization.nix
   # ./hardening.nix
-  # ./nss-hardening.nix
+  ./nss-hardening.nix
   # ./integrity.nix
   # ./mta.nix
 ]


### PR DESCRIPTION
anssi: implement R66 — NSS hardening

Restricts `/etc/nsswitch.conf`'s `hosts:` line to `files dns`
only, eliminating:

  * `mdns4_minimal` / `mdns6_minimal` (Avahi / zeroconf)
  * `nis`, `nisplus`, `wins`, `winbind` (legacy, insecure)
  * `mymachines` (container name resolution — irrelevant on a
    workstation that does not host local `systemd-nspawn`
    containers)
  * `myhostname` (self-translation, redundant with `/etc/hosts`)

Defensively also forces `services.avahi.nssmdns4 = false` and
`services.avahi.nssmdns6 = false` so that an operator re-enabling
Avahi later does not silently reintroduce mDNS into NSS.

Tagged `nss-hardening` — exclude with
`security.anssi.excludes = [ "nss-hardening" ]`.

## Scope change vs earlier revision

An earlier revision of this branch bundled an R15-framed
container-disabling module (`runtime-minimization.nix`). Per
reviewer feedback, that bundling conflated two distinct concerns
— R15 is "disable unused services" in the ANSSI guide, not
specifically "no container engine" — so I dropped the container
piece from this PR. If a standalone Sécurix policy for banning
local container runtimes is wanted, I can open it as a separate
non-ANSSI module in a follow-up PR.

## Validation

```
$ nix-build -A tests.full -o result
$ grep '^hosts:' result/etc/nsswitch.conf
hosts: files dns
```

Refs:
- ANSSI v2.0 R66 — *Restreindre les mécanismes de résolution de noms*

---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
