### PR TITLE
wireguard : livre l'outillage rosenpass + documente la mise en place PQ

### DIFF
--- a/modules/vpn/wireguard/README.md
+++ b/modules/vpn/wireguard/README.md
@@ -1,6 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2025 Elias Coppens <elias.coppens@numerique.gouv.fr>
 SPDX-FileContributor: 2025 Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>
+SPDX-FileContributor: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
 
 SPDX-License-Identifier: MIT
 -->
@@ -75,3 +76,87 @@ Once your VPN profile is installed, use the following commands to manage it:
 
 - `wireguard-<vpn-name> down`  
   Deactivates the VPN.
+
+## Échange de clés post-quantique (Rosenpass)
+
+Le handshake natif de WireGuard utilise **Curve25519** (ECDH
+classique). Un attaquant capable d'enregistrer le handshake aujourd'hui
+pourrait, une fois les
+[CRQC](https://en.wikipedia.org/wiki/Cryptographically_relevant_quantum_computer)
+disponibles, dériver les clés de session rétroactivement et déchiffrer
+tout le trafic capturé — le classique risque *harvest-now-decrypt-later*.
+
+[Rosenpass](https://rosenpass.eu) superpose un KEM post-quantique
+standardisé NIST (hybride Classic McEliece + CRYSTALS-Kyber)
+**par-dessus** le handshake WireGuard et injecte un PSK rafraîchi dans
+chaque peer au moment de l'accord de clé. WireGuard intègre ensuite ce
+PSK dans son état Noise, de sorte que même une connaissance complète
+du handshake Curve25519 ne permet pas le déchiffrement.
+
+### Pré-requis
+
+`securix.vpn.wireguard.rosenpass.enable = true;` (défaut quand
+`wireguard.enable = true`) garantit que le binaire `rosenpass` est
+dans le PATH système.
+
+### Mise en place unique par profil
+
+1. **Générer une paire de clés Rosenpass sur chaque peer** (les deux côtés, une seule fois) :
+
+   ```bash
+   sudo rosenpass gen-keys --secret-key /etc/rosenpass/<profile>.sk \
+                            --public-key /etc/rosenpass/<profile>.pk
+   ```
+
+2. **Échanger les clés publiques** avec l'admin du peer via un canal
+   authentifié (email+GPG, Signal, en présentiel). Copier la `.pk` du
+   peer dans `/etc/rosenpass/<profile>.peer.pk`.
+
+3. **Activer le service rosenpass système** (module NixOS upstream)
+   avec la configuration de votre profil :
+
+   ```nix
+   services.rosenpass = {
+     enable = true;
+     defaultDevice = "wg0";  # doit matcher votre interface WG
+     settings = {
+       public_key = "/etc/rosenpass/<profile>.pk";
+       secret_key = "/etc/rosenpass/<profile>.sk";
+       listen = [ "0.0.0.0:9999" ];  # UDP, port distinct de WG
+       peers = [
+         {
+           public_key = "/etc/rosenpass/<profile>.peer.pk";
+           endpoint = "<peer-ip>:9999";
+           # Le PSK que Rosenpass injecte via `wg set peer <wg-pubkey> preshared-key -`
+         }
+       ];
+     };
+   };
+   ```
+
+4. **Monter WG comme d'habitude** — `wireguard-<profile> up`. L'unité
+   systemd `rosenpass.service` démarre à côté, négocie un PSK PQ avec
+   le peer, et fait tourner en continu le PSK qu'elle injecte dans
+   l'interface WG.
+
+### Caveats
+
+- Rosenpass utilise un **port UDP séparé** de WireGuard (typiquement
+  9999). Veiller à ce que votre firewall l'autorise entre les peers.
+- Rosenpass n'authentifie pas le peer par lui-même — il s'appuie sur
+  le handshake à clé publique de l'étape 2. Perdre le contrôle de la
+  `.pk` d'un peer casse la couche PQ (le WG classique continue de
+  fournir l'authentification via la clé publique Curve25519).
+- Rosenpass ajoute ~50 ms à chaque fenêtre de re-key (par défaut
+  toutes les ~2 minutes). Négligeable pour des sessions admin.
+- Non testé avec des clés Rosenpass portées par YubiKey — le démon
+  lit la `.sk` sur disque. Pour un keypair PQ matériel, suivre les
+  issues Rosenpass upstream.
+
+### Modèle de menace après Rosenpass
+
+| Contre | WG seul | WG + Rosenpass |
+|---|---|---|
+| Aujourd'hui : extraction de clé depuis handshake capturé | ✓ protégé (Curve25519 solide) | ✓ |
+| Aujourd'hui : MITM actif avec privkey peer WG volée | ✗ tunnel détourné | ✗ toujours détournable (Rosenpass s'appuie sur l'auth WG) |
+| **2035+ : déchiffrement du trafic capturé aujourd'hui via CRQC** | ✗ **vulnérable** | ✓ **protégé (McEliece + Kyber)** |

--- a/modules/vpn/wireguard/default.nix
+++ b/modules/vpn/wireguard/default.nix
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Elias Coppens <elias.coppens@numerique.gouv.fr>
+# SPDX-FileContributor: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
 #
 # SPDX-License-Identifier: MIT
 
@@ -26,10 +27,13 @@ let
     map
     mkIf
     mkEnableOption
+    mkOption
+    types
     nameValuePair
     unique
     mapAttrs
     splitString
+    optional
     ;
 
   selectWireguardVpns =
@@ -137,6 +141,26 @@ in
 {
   options.securix.vpn.wireguard = {
     enable = mkEnableOption "the Wireguard VPN subsystem";
+
+    rosenpass = {
+      enable = mkOption {
+        type = types.bool;
+        default = cfg.enable;
+        defaultText = lib.literalExpression "config.securix.vpn.wireguard.enable";
+        description = ''
+          Livre l'outillage d'échange de clés post-quantique `rosenpass`
+          dans le PATH système. Rosenpass superpose un KEM post-quantique
+          standardisé NIST au-dessus du handshake Noise de WireGuard,
+          neutralisant le risque « harvest now, decrypt later » contre
+          le handshake Curve25519 de WG.
+
+          Cette option n'installe que les binaires ; l'activation par
+          profil est opt-in (voir `docs/rosenpass.md` ou le README
+          WireGuard Sécurix). Désactiver cette option masque simplement
+          les binaires — cela ne casse pas les connexions WG existantes.
+        '';
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -144,7 +168,8 @@ in
       pkgs.wireguard-tools
       pkgs.age
       pkgs.age-plugin-yubikey
-    ];
+    ]
+    ++ optional cfg.rosenpass.enable pkgs.rosenpass;
 
     users.users = mapAttrs (username: config: {
       packages = concatMap (


### PR DESCRIPTION
wireguard : livre l'outillage rosenpass + documente la mise en place PQ

Adresse la lacune post-quantique du handshake natif WireGuard.

## Pourquoi

Le handshake Noise de WireGuard utilise Curve25519 (ECDH classique).
Un adversaire capturant le handshake aujourd'hui pourrait, une fois
les ordinateurs quantiques cryptographiquement pertinents
disponibles, dériver les clés de session rétroactivement et
déchiffrer tout le trafic — le classique problème
« harvest-now-decrypt-later ».

Rosenpass (rosenpass.eu) superpose un KEM post-quantique standardisé
NIST (hybride Classic McEliece + CRYSTALS-Kyber) au-dessus du
handshake WG et injecte un PSK rotatif dans chaque peer. Après ce
PR, les profils WG d'un poste Sécurix peuvent opter pour la
protection PQ sans re-packaging ni flakes supplémentaires.

## Ce que ça change

Scope minimal :

  * `pkgs.rosenpass` est ajouté à `environment.systemPackages` quand
    `securix.vpn.wireguard.enable = true` (contrôlé par une nouvelle
    option `securix.vpn.wireguard.rosenpass.enable`, défaut-on),
  * le README.md reçoit une section « Échange de clés post-quantique
    (Rosenpass) » qui déroule la génération des keypairs, l'échange
    avec le peer, et la configuration upstream `services.rosenpass.*`.

Délibérément HORS scope (suivi à faire séparément) :

  * le câblage automatique systemd par profil. Le module WG actuel
    est un modèle de scripts up/down manuel par utilisateur ;
    ajouter des services rosenpass par profil demande un refactor
    plus profond de `mkWireGuardScripts` et se fait mieux dans son
    propre PR une fois que l'équipe s'est accordée sur la forme,
  * des clés Rosenpass portées par YubiKey (.sk PIV-wrappé). Le
    rosenpass upstream lit la `.sk` depuis disque aujourd'hui ;
    cette limitation est appelée dans le README.

## Validation

  * Build via `tests.full` avec `vpn.wireguard.enable = true`,
  * binaire `rosenpass` présent dans `/run/current-system/sw/bin`,
  * README rendu par mdbook (même toolchain que `docs/manual`).

## Gain modèle de menace

Contre un attaquant capturant les handshakes WG aujourd'hui et les
revisitant en 2035+ avec un CRQC :

  * WG seul        → trafic récupérable
  * WG + Rosenpass → trafic reste secret (McEliece + Kyber)

Refs : https://rosenpass.eu/ — audit PQC Sécurix
(store-now-decrypt-later gap 2)
