### PR TITLE
vpn/ipsec: post-quantum hybrid KEX for IKEv2 (RFC 9370)

### DIFF
--- a/modules/vpn/ipsec/default.nix
+++ b/modules/vpn/ipsec/default.nix
@@ -9,5 +9,7 @@
     ./networkmanager.nix
     # Firewall rules to go always to the IPsec tunnel
     ./firewall.nix
+    # Post-quantum hybrid KEX for IKEv2 (RFC 9370)
+    ./post-quantum.nix
   ];
 }

--- a/modules/vpn/ipsec/networkmanager.nix
+++ b/modules/vpn/ipsec/networkmanager.nix
@@ -31,6 +31,24 @@ let
     mkDefault
     mkRenamedOptionModule
     ;
+  # See modules/vpn/ipsec/post-quantum.nix for the options declaration.
+  pqCfg = config.securix.vpn.ipsec.postQuantum;
+  # Append the post-quantum additional KE round to an IKE proposal
+  # string unless the operator already put one there. Matches ke1_*,
+  # mlkem*, kyber* to avoid double-appending when the proposal was
+  # written PQ-aware in the inventory.
+  wrapIkePq =
+    ike:
+    if
+      pqCfg.enable
+      && !(lib.hasInfix "ke1_" ike)
+      && !(lib.hasInfix "ke2_" ike)
+      && !(lib.hasInfix "mlkem" ike)
+      && !(lib.hasInfix "kyber" ike)
+    then
+      "${ike}-${pqCfg.additionalKe}"
+    else
+      ike;
   isValidIpsecProfile =
     profileName: hasAttr profileName vpnProfiles && vpnProfiles.${profileName}.type == "ipsec";
   mapValidIpsecProfiles =
@@ -104,7 +122,8 @@ let
         # It's automatically derived when the cert is on the smartcard.
         local-identity = mkIf (method != "cert-on-security-token") email;
         proposal = "yes";
-        inherit ike esp;
+        ike = wrapIkePq ike;
+        inherit esp;
         remote-ts = concatStringsSep ";" remoteSubnets;
         local-ts = mkIf (mkAddress != null) (mkAddress bit);
         virtual = if (localSubnet == "%any") then "yes" else "no";

--- a/modules/vpn/ipsec/post-quantum.nix
+++ b/modules/vpn/ipsec/post-quantum.nix
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# Post-quantum hybrid key exchange for IPsec / IKEv2 (RFC 9370).
+#
+# strongSwan 6.x ships with native ML-KEM support via the openssl
+# plugin when built against OpenSSL 3.5+ — which is already the case
+# on nixpkgs 25.11 (OpenSSL 3.6). Enabling PQ IKE is therefore not
+# about adding a plugin or a crypto overlay (AWS-LC, botan3) but about
+# *appending an additional KE round* to the existing IKE proposal
+# strings configured per-VPN in the inventory.
+#
+# RFC 9370 defines additional KE rounds chained with the primary
+# Diffie-Hellman (classical) group. The resulting session key is
+# derived from BOTH — so the session remains secure as long as *one*
+# of the two components resists an adversary. With classical X25519
+# paired with ML-KEM-768, a `harvest-now-decrypt-later` attacker
+# needs to break *both* to recover past traffic.
+#
+# When this module's `enable = true`, every IKE proposal generated
+# for a NetworkManager strongSwan connection gets `-ke1_mlkem768`
+# appended (or the operator-chosen `additionalKe`). strongSwan and
+# NetworkManager handle fallback automatically: if the peer does not
+# support RFC 9370, the additional-KE round is simply skipped and a
+# classical-only session is established.
+#
+# Zero-disruption rollout: legacy peers still work, modern peers get
+# PQ. No rebuild, no overlay, just a string suffix.
+{ config, lib, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  options.securix.vpn.ipsec.postQuantum = {
+    enable = mkEnableOption ''
+      hybrid post-quantum key exchange for IPsec IKEv2 proposals.
+      Appends an additional KE round (default ML-KEM-768) to every
+      per-VPN IKE proposal. Requires strongSwan 6.x (already shipped
+      in nixpkgs 25.11) on both sides. Peers without RFC 9370 support
+      fall back to classical negotiation transparently.
+    '';
+
+    additionalKe = mkOption {
+      type = types.str;
+      default = "ke1_mlkem768";
+      description = ''
+        Additional KE suffix appended to the IKE proposal.
+        Must match the strongSwan proposal syntax for RFC 9370:
+
+          ke1_mlkem512    — ML-KEM-512   (NIST PQ security level 1)
+          ke1_mlkem768    — ML-KEM-768   (NIST PQ level 3, recommended)
+          ke1_mlkem1024   — ML-KEM-1024  (NIST PQ level 5)
+
+        `ke2_*`, `ke3_*` etc. chain additional rounds; generally not
+        useful unless you're experimenting with crypto diversification.
+      '';
+      example = "ke1_mlkem1024";
+    };
+  };
+}


### PR DESCRIPTION
vpn/ipsec: post-quantum hybrid KEX for IKEv2 (RFC 9370)

Closes the IPsec KEX gap in Sécurix's PQ audit. strongSwan 6.0.3
(shipped in nixpkgs 25.11) supports ML-KEM natively when built
against OpenSSL 3.5+ (3.6 on current pin) — no plugin, no AWS-LC
override, no rebuild of nixpkgs required.

## Approach

Rather than refactoring the inventory schema, this wraps the
existing `ike` proposal string of each per-VPN NetworkManager
connection profile. When `postQuantum.enable = true`, a configurable
additional-KE suffix (default `ke1_mlkem768`) is appended to every
IKE proposal that doesn't already carry one.

Idempotent: the wrapper checks for `ke1_`, `ke2_`, `mlkem`, `kyber`
substrings and skips wrapping when the inventory proposal is already
PQ-aware — so operators keeping a custom proposal retain full control.

## Transformation

  ike (inventory)                              | wrapped (enable=true)
  ---------------------------------------------+--------------------------------------------------
  aes256gcm16-prfsha384-x25519                 | aes256gcm16-prfsha384-x25519-ke1_mlkem768
  aes256gcm16-prfsha384-x25519-ke1_mlkem768    | aes256gcm16-prfsha384-x25519-ke1_mlkem768 (unchanged)
  aes256gcm16-prfsha384-x25519-ke1_kyber768    | aes256gcm16-prfsha384-x25519-ke1_kyber768 (unchanged)

## Interop safety (no disruption)

RFC 9370 defines the additional-KE round as *optional*. If a peer
does not advertise it, strongSwan completes the handshake with the
primary KE only (classical X25519). Enabling this module on the
Sécurix end therefore cannot break existing tunnels to legacy
peers — it silently upgrades tunnels to PQ only when both ends
support RFC 9370.

This matches the pattern we use for SSH PQ KEX (#145) and outbound
TLS PQ (#144): PQ preferred, classical fallback, no forced policy.

## Threat model gain

| Against                                           | Before | After |
|---------------------------------------------------|--------|-------|
| Passive capture → session key derive              | ✓      | ✓     |
| 2035+ replay-with-CRQC on captured IKE handshake  | ✗      | ✓     |
| IPsec data traffic decryption in 15 years         | ✗      | ✓     |

## Options

  securix.vpn.ipsec.postQuantum = {
    enable = true;                    # default off — opt-in per ops policy
    additionalKe = "ke1_mlkem768";    # default: ML-KEM-768 (NIST PQ level 3)
                                      # alternatives: ke1_mlkem512, ke1_mlkem1024
  };

## Validation

  * Module compiles cleanly against tests.full
  * `wrapIkePq` verified against 5 cases (disabled, enabled-classical,
    already-pq-mlkem, already-pq-kyber, disabled-already-pq) — all
    correct
  * strongSwan 6.0.3 + OpenSSL 3.6.0 confirmed in closure:
      $ find /nix/store -name libstrongswan-openssl.so  # present
      $ strongswan --version  # 6.0.3

## Follow-up (separate PR)

AWS-LC as strongSwan crypto backend (performance gain 15-30% on
AES-GCM / SHA2 per AWS benchmarks) is a separate concern: it
requires a nixpkgs overlay and changes the crypto audit surface —
ANSSI-relevant enough to warrant its own design discussion before
code. This PR focuses purely on enabling PQ via the stock
`strongswan` + `openssl` combination already in nixpkgs 25.11.

Refs: RFC 9370 — Multiple Key Exchanges in IKEv2
Refs: strongSwan 6.0 release notes — native ML-KEM support via openssl plugin
Refs: Sécurix PQC audit — Gap 1 (IPsec KEX classical)


---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
