### PR TITLE
vfs: harden /tmp, /var/tmp, /dev/shm (ANSSI R19)

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -28,6 +28,8 @@
     ./ssh-tpm-agent.nix
     # Audit logs
     ./auditd.nix
+    # /tmp, /var/tmp, /dev/shm hardening (ANSSI R19)
+    ./vfs.nix
     # Data-only pertaining to the system
     ./self.nix
     # All the VPN code

--- a/modules/vfs.nix
+++ b/modules/vfs.nix
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# ANSSI R19 — Désactiver les options de montage dangereuses sur les
+# systèmes de fichiers sensibles (/tmp, /var/tmp, /dev/shm).
+#
+# `/tmp`, `/var/tmp` et `/dev/shm` sont des vecteurs classiques
+# d'exécution de binaires posés par un attaquant ayant obtenu un
+# write-to-disk primitive (exploit navigateur, fichier téléchargé,
+# shared memory SysV). Les options `noexec`, `nosuid`, `nodev`
+# neutralisent trois des principaux vecteurs :
+#
+#   * `noexec`  — le kernel refuse d'exécuter un binaire depuis ce mount
+#   * `nosuid`  — ignore le bit SUID/SGID (pas de privilege escalation
+#                 via un binaire déposé)
+#   * `nodev`   — ignore les device files (pas d'accès direct aux
+#                 périphériques via une entrée fraîchement créée)
+#
+# Particularité NixOS : le daemon Nix (nix-daemon) utilise `/tmp` pour
+# les sandbox de build, et ces sandbox exécutent des scripts de build.
+# Un `/tmp` en `noexec` casserait toutes les builds. Ce module crée un
+# répertoire dédié `/var/lib/nix/build` (exempté de `noexec`) et
+# oriente nix-daemon dessus via `TMPDIR` + `nix.settings.build-dir`.
+{ config, lib, ... }:
+let
+  cfg = config.securix.vfs;
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    optional
+    ;
+in
+{
+  options.securix.vfs = {
+    hardenTmpfs = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+
+          Monte `/tmp`, `/var/tmp` et `/dev/shm` avec les options
+          ANSSI R19 (`noexec,nosuid,nodev`). Default-on ; désactivable
+          pour les postes de dev qui déploient des sandbox custom.
+        '';
+      };
+
+      tmpSize = mkOption {
+        type = types.str;
+        default = "50%";
+        description = "Taille allouée à `/tmp` (tmpfs).";
+      };
+
+      varTmpSize = mkOption {
+        type = types.str;
+        default = "25%";
+        description = "Taille allouée à `/var/tmp` (tmpfs).";
+      };
+
+      tmpExec = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+
+          Autorise l'exécution depuis `/tmp`. Utile uniquement si
+          vous orchestrez nix-daemon (ou un autre service sensible)
+          manuellement sans passer par `nixBuildTmpdir`. Défaut :
+          `false` — `/tmp` est `noexec` et nix-daemon est routé vers
+          `nixBuildTmpdir`.
+        '';
+      };
+
+      nixBuildTmpdir = mkOption {
+        type = types.path;
+        default = "/var/lib/nix/build";
+        description = ''
+
+          Répertoire exécutable dédié à nix-daemon pour les sandbox
+          de build. Monté sur le rootfs (pas en tmpfs pour que les
+          gros builds ne remplissent pas la RAM). La sandbox Nix
+          fait son propre chroot par-dessus, donc les binaires qui
+          s'y exécutent ne sont pas accessibles depuis l'extérieur.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.hardenTmpfs.enable {
+    fileSystems."/tmp" = {
+      device = "tmpfs";
+      fsType = "tmpfs";
+      options = [
+        "size=${cfg.hardenTmpfs.tmpSize}"
+        "mode=1777"
+        "nosuid"
+        "nodev"
+      ]
+      ++ optional (!cfg.hardenTmpfs.tmpExec) "noexec";
+    };
+
+    fileSystems."/var/tmp" = {
+      device = "tmpfs";
+      fsType = "tmpfs";
+      options = [
+        "size=${cfg.hardenTmpfs.varTmpSize}"
+        "mode=1777"
+        "noexec"
+        "nosuid"
+        "nodev"
+      ];
+    };
+
+    fileSystems."/dev/shm" = {
+      device = "tmpfs";
+      fsType = "tmpfs";
+      options = [
+        "mode=1777"
+        "noexec"
+        "nosuid"
+        "nodev"
+      ];
+    };
+
+    # Répertoire de build dédié à nix-daemon — vit sur le rootfs pour
+    # que les builds multi-Go ne fassent pas exploser tmpfs/RAM, et
+    # le chemin est exec-capable (contrairement à `/tmp`).
+    # `nix.settings.build-dir` est le paramètre faisant autorité
+    # depuis Nix 2.21 / Lix 2.91 — le démon le lit au démarrage et
+    # y route le mount `/build` de chaque sandbox.
+    systemd.tmpfiles.rules = mkIf (!cfg.hardenTmpfs.tmpExec) [
+      "d ${cfg.hardenTmpfs.nixBuildTmpdir} 0755 root root -"
+    ];
+
+    nix.settings.build-dir = mkIf (!cfg.hardenTmpfs.tmpExec) cfg.hardenTmpfs.nixBuildTmpdir;
+  };
+}


### PR DESCRIPTION
vfs: harden /tmp, /var/tmp, /dev/shm (ANSSI R19)

/tmp, /var/tmp and /dev/shm are the canonical landing zones for a
binary dropped by an attacker with a write-to-disk primitive
(browser exploit, downloaded file, SysV shared memory injection).
This PR mounts them tmpfs with `noexec,nosuid,nodev` per ANSSI R19.

## What

New module `modules/vfs.nix` exposing:

```nix
securix.vfs.hardenTmpfs = {
  enable = true;                        # default on
  tmpSize = "50%";
  varTmpSize = "25%";
  tmpExec = false;                      # toggle if /tmp must be exec
  nixBuildTmpdir = "/var/lib/nix/build"; # exec-capable sandbox path for nix-daemon
};
```

## NixOS-specific caveat

nix-daemon builds packages in a sandbox that executes build scripts.
That sandbox's `/build` mount historically lived under `/tmp`, so a
bare `/tmp noexec` would break every Nix build. This PR points
nix-daemon at a dedicated exec-capable directory outside `/tmp`:

- `nix.settings.build-dir = /var/lib/nix/build` — authoritative in
  Nix ≥ 2.21 / Lix ≥ 2.91. nix-daemon reads it at startup and
  routes every sandbox's `/build` mount there.
- `systemd.tmpfiles.rules` creates the directory at boot
  with `0755 root:root`.

Builds land in `/var/lib/nix/build/nix-build-*` on the root
filesystem (no tmpfs size ceiling, so multi-GB builds succeed) and
execute under the Nix sandbox's chroot — nothing outside the build
sees those binaries.

A user-space workflow that currently drops an executable into
`/tmp` and then `chmod +x && ./foo` must either use `$TMPDIR` /
`/var/lib/nix/build`, or the operator flips
`securix.vfs.hardenTmpfs.tmpExec = true` on that specific host.

## Validation

Built `tests.full` with the module enabled:

```
$ grep '^tmpfs' result/etc/fstab
tmpfs /dev/shm tmpfs mode=1777,noexec,nosuid,nodev 0 0
tmpfs /tmp     tmpfs size=50%,mode=1777,nosuid,nodev,noexec 0 0
tmpfs /var/tmp tmpfs size=25%,mode=1777,noexec,nosuid,nodev 0 0

$ grep build-dir result/etc/nix/nix.conf
build-dir = /var/lib/nix/build

$ grep /var/lib/nix/build result/etc/tmpfiles.d/00-nixos.conf
d /var/lib/nix/build 0755 root root -
```

## Threat model gain

| Vector | Before | After |
|---|---|---|
| Drop-a-binary-then-exec in /tmp | open | noexec |
| SUID escalation via /tmp payload | open | nosuid |
| Device smuggling via /dev/shm | open | nodev |
| Legitimate Nix builds | ok | ok (via build-dir) |

## Opt-out

Hosts with custom sandbox tooling that needs exec in /tmp can set
`securix.vfs.hardenTmpfs.tmpExec = true` (keeps /var/tmp and
/dev/shm hardened), or disable the whole module with
`enable = false`.

Refs:
- ANSSI v2.0 R19 — *Désactiver les options de montage dangereuses*
- CIS Distribution-Independent Linux Benchmark 1.1.2–14

---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
