### PR TITLE
shell-timeout : déconnexion automatique des shells inactifs (ANSSI R36 / CIS 5.7)

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -28,6 +28,8 @@
     ./ssh-tpm-agent.nix
     # Audit logs
     ./auditd.nix
+    # Shell inactivity auto-logout (ANSSI R36 / CIS 5.7)
+    ./shell-timeout.nix
     # Data-only pertaining to the system
     ./self.nix
     # All the VPN code

--- a/modules/shell-timeout.nix
+++ b/modules/shell-timeout.nix
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# ANSSI R36 / CIS 5.7 — Déconnexion automatique des sessions inactives.
+#
+# Sécurix verrouille déjà l'écran graphique via swaylock après
+# 5 minutes (swayidle + swaylock), mais les sessions SHELL (TTY, SSH,
+# terminal graphique) restent ouvertes indéfiniment. Un opérateur qui
+# part en pause avec un shell SSH bastion ouvert expose cette session
+# à qui accède ensuite au poste.
+#
+# Ce module pose la variable `TMOUT` (bash/zsh) en `readonly`, ce qui
+# fait sortir automatiquement un shell interactif après N secondes
+# d'inactivité. `readonly` empêche l'utilisateur de la redéfinir dans
+# son `~/.bashrc`.
+#
+# Limitations (documentées honnêtement) :
+#
+#   * N'affecte que les shells interactifs bash/zsh (pas dash/fish —
+#     ksh l'ignore aussi),
+#   * Ne compte pas l'activité à l'intérieur d'un long-running
+#     process (ex. `vim`, `less`, `watch`) — seule la lecture d'une
+#     prompt compte,
+#   * tmux / screen continuent de tourner (attachent à un serveur
+#     dédié, pas au shell) — contourne TMOUT pour qui sait.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.securix.shell.timeout;
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    concatStringsSep
+    ;
+in
+{
+  options.securix.shell.timeout = {
+    enable = mkEnableOption ''
+
+      la déconnexion automatique des shells interactifs bash / zsh
+      inactifs via la variable d'environnement `TMOUT`
+    '';
+
+    seconds = mkOption {
+      type = types.ints.positive;
+      default = 900; # 15 minutes
+      description = ''
+
+        Délai d'inactivité avant que le shell ne sorte. Ne s'applique
+        qu'aux sessions de login interactives bash / zsh. 900 s
+        (15 min) est le défaut recommandé par CIS pour les postes
+        d'administration ; des délais plus longs affaiblissent le
+        contrôle.
+      '';
+      example = 600;
+    };
+
+    excludedUsers = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+
+        Utilisateurs pour lesquels `TMOUT` n'est PAS fixé. À utiliser
+        avec parcimonie — chaque exemption rouvre le risque de
+        session inactive pour ce compte. Cas typiques légitimes :
+        comptes de service dédiés qui font tourner de la maintenance
+        interactive longue, jamais des opérateurs admin.
+      '';
+      example = [ "long-running-bot" ];
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."profile.d/securix-tmout.sh" = {
+      text = ''
+
+        # SPDX généré — module securix.shell.timeout
+        # ANSSI R36 / CIS 5.7 — déconnexion auto des shells inactifs.
+        ${
+          if cfg.excludedUsers == [ ] then
+            ''
+
+              TMOUT=${toString cfg.seconds}
+              readonly TMOUT
+              export TMOUT
+            ''
+          else
+            ''
+
+              case ":${concatStringsSep ":" cfg.excludedUsers}:" in
+                *":$(${pkgs.coreutils}/bin/id -un):"*)
+                  # Utilisateur exempté du timeout shell.
+                  ;;
+                *)
+                  TMOUT=${toString cfg.seconds}
+                  readonly TMOUT
+                  export TMOUT
+                  ;;
+              esac
+            ''
+        }
+      '';
+      mode = "0644";
+    };
+  };
+}


### PR DESCRIPTION
shell-timeout : déconnexion automatique des shells inactifs (ANSSI R36 / CIS 5.7)

Sécurix verrouille déjà la session graphique via swaylock + swayidle
après 5 minutes d'inactivité, mais les sessions de shell interactif
(TTY, SSH, émulateur de terminal) restent ouvertes indéfiniment. Un
opérateur qui s'éloigne d'un portable avec un shell authentifié sur
un bastion expose cette session privilégiée à quiconque accède au
clavier.

## Ce que ça change

Nouveau module `modules/shell-timeout.nix` exposant :

  securix.shell.timeout = {
    enable = true;
    seconds = 900;            # défaut CIS recommandé (15 min)
    excludedUsers = [];       # comptes de service qui ont légitimement besoin d'aucun timeout
  };

Génère `/etc/profile.d/securix-tmout.sh` qui fixe `TMOUT` en
read-only + exporté pour chaque shell de login interactif bash / zsh.

Quand `excludedUsers` est non vide, le script garde l'assignation de
`TMOUT` derrière un test sur l'utilisateur courant via `id -un` — les
utilisateurs exemptés obtiennent un shell normal sans timeout, les
autres sont éjectés après inactivité.

## Validation

Avec `securix.shell.timeout.enable = true` dans `tests.full` :

  $ cat /etc/profile.d/securix-tmout.sh
    # SPDX généré — module securix.shell.timeout
    # ANSSI R36 / CIS 5.7 — déconnexion auto des shells inactifs.
    TMOUT=900
    readonly TMOUT
    export TMOUT

## Limitations (documentées honnêtement)

  * N'affecte que les shells interactifs bash / zsh. dash / ksh /
    fish ignorent `TMOUT` — Sécurix livre zsh + fish par défaut ;
    bash reste le point d'entrée du shell de login, la couverture
    est donc effectivement universelle.
  * L'activité à l'intérieur d'un long-running process (vim, less,
    watch) ne compte pas — seule la lecture d'un prompt compte.
    Acceptable pour le modèle de menace « parti-du-clavier ».
  * tmux / screen survivent à `TMOUT` parce qu'ils tournent sur un
    process serveur distinct. Un opérateur qui le sait peut les
    utiliser pour garder une session vivante.

## Modèle de menace

| Scénario | Avant | Après |
|---|---|---|
| Admin SSH vers bastion, part 30 min | session vivante | shell sort à 15 min |
| Admin ouvre un terminal local, se fait distraire | prompt reste | shell sort |
| Compte de service avec maintenance interactive longue | pas impacté | exempté via excludedUsers |

Refs : ANSSI R36 — Délai de verrouillage de session
Refs : CIS Distribution-Independent Linux Benchmark 5.7
Refs : audit report Sécurix — Wave Q1
