### PR TITLE
anssi: extend R12 with log_martians + tcp_timestamps=0

### DIFF
--- a/modules/anssi/kernel-options.nix
+++ b/modules/anssi/kernel-options.nix
@@ -237,6 +237,24 @@ in
 
         # Enable SYN cookies (prevents SYN flood attacks)
         "net.ipv4.tcp_syncookies" = "1";
+
+        # Log packets with impossible / spoofed source addresses.
+        # Already dropped by rp_filter above; logging them here gives
+        # forensic visibility on active probing / spoofing attempts.
+        # Not formally part of ANSSI R12 in the v2.0 guide; added as
+        # a Sécurix-local complement. See RFC 3704 for the concept.
+        "net.ipv4.conf.all.log_martians" = "1";
+        "net.ipv4.conf.default.log_martians" = "1";
+
+        # Disable TCP timestamps (RFC 1323). The option supports PAWS on
+        # connections transferring more than 2^31 bytes in a single TCP
+        # flow — a scenario that does not happen on a workstation. What
+        # it does leak reliably is the system uptime to any remote peer
+        # that captures a SYN-ACK, usable for OS fingerprinting and
+        # attack timing. Not part of R12 in the ANSSI v2.0 guide;
+        # included as a Sécurix-local complement. See RFC 1323 §4,
+        # and https://lwn.net/Articles/581578/ for the uptime-leak.
+        "net.ipv4.tcp_timestamps" = "0";
       };
     in
     {


### PR DESCRIPTION
anssi: extend R12 with log_martians + tcp_timestamps=0

Adds two IPv4 sysctls to the R12 IPv4-networking ruleset:

- `net.ipv4.conf.{all,default}.log_martians = 1`
- `net.ipv4.tcp_timestamps = 0`

## Honest framing

These two sysctls are **not in the ANSSI v2.0 guide** under R12 or
R24 (an earlier version of this PR claimed R24 — that was wrong,
R24 is about 32-bit architectures). I'm framing them as **Sécurix
hardening that belongs in the R12 IPv4 block** because that's
where the rest of the network sysctl surface lives, not as
ANSSI-prescribed rules.

If you'd rather not colocate non-ANSSI tweaks in the R12 closure, I
can instead extract them into a separate `modules/networking.nix`
block (or any other location you prefer). Let me know.

## `log_martians`

Packets with impossible / spoofed source addresses are already
dropped by the `rp_filter = 1` rule already in R12. Turning on
`log_martians` adds a dmesg / journald entry per drop, giving
forensic visibility on active probing. Zero behavioural change on
the network path. Some extra log volume on misconfigured-DHCP
networks — bounded by the journald retention module (PR #139).

Refs: RFC 3704 (reverse-path validation semantics).

## `tcp_timestamps = 0`

RFC 1323 TCP timestamps enable PAWS on TCP flows transferring more
than 2^31 bytes — a scenario that does not occur on a workstation.
What they do leak reliably is the system uptime to any remote peer
that captures a SYN-ACK, usable for:

- OS fingerprinting (uptime patterns differ across OS families)
- attack timing (synchronize an exploit with a fresh boot)
- patch-window identification

Refs: RFC 1323 §4, LWN https://lwn.net/Articles/581578/ on
uptime leakage.

## Scope

Pure sysctl additions to an already-loaded R12 closure. No new
module, no new options. The yama `ptrace_scope=2` tweak that a
previous revision of this branch accidentally included belongs to
#133 and has been removed from this PR.

---

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
