### PR TITLE
anssi : R15b — désactivation de la pile Bluetooth userspace (CIS 3.1.4)

### DIFF
--- a/modules/anssi/no-bluetooth.nix
+++ b/modules/anssi/no-bluetooth.nix
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+#
+# SPDX-License-Identifier: MIT
+
+# ANSSI R15 (sous-ensemble Bluetooth) / CIS 3.1.4 — désactivation
+# complète de la pile Bluetooth locale.
+#
+# Historique CVE de la pile Bluetooth Linux (BlueZ + kernel) :
+#
+#   2017  BlueBorne (8 CVEs)        RCE sans pairing, sans user interaction
+#   2019  KNOB                      forçage PIN 1-byte, MITM complet
+#   2020  BIAS                      impersonation de peer appairé
+#   2020  BleedingTooth (kernel)    RCE via L2CAP, CVSS 8.3
+#   2021  BrakTooth (16 CVEs)       crash + potentiel RCE
+#   2022  DirtyBT / RCE USB stack   CVE-2022-47521 et suivants
+#   2023  BLUFFS                    MITM sur session (6 CVEs)
+#   2024  Flipper-Zero remote DoS
+#
+# Soit une cadence d'environ 1 famille de CVE par an depuis 8 ans,
+# toutes exploitables à proximité physique (quelques mètres) sans
+# pairing préalable pour la plupart. Sur un admin workstation qui
+# voyage (aéroports, trains, cafés), c'est la plus grosse surface
+# d'attaque passive non-fermable sans matériel spécifique.
+#
+# Sécurix cible des postes d'administration ANSSI-conformes ; cette
+# règle désactive DEUX couches :
+#
+#   1. Service systemd      `services.blueman.enable = false`
+#                           `hardware.bluetooth.enable = false`
+#   2. Assertion build-time sur `hardware.bluetooth.enable` — un
+#      opérateur qui tente de réactiver BT sans exclure la règle
+#      voit l'échec à `nixos-rebuild`, avec le message qui pointe
+#      vers `security.anssi.excludes`.
+#
+# Les modules kernel bluez NE SONT PAS blacklistés. Ça laisse la
+# possibilité à un opérateur qui en a besoin temporairement de :
+#
+#   a) brancher un dongle USB BT (le kernel charge le module)
+#   b) excluer la règle dans sa config (`excludes = [ "bluetooth" ]`)
+#   c) activer le service (`hardware.bluetooth.enable = true`)
+#   d) `nixos-rebuild switch` — **pas de reboot nécessaire**.
+#
+# Pourquoi pas blacklister les modules aussi : le blacklist kernel
+# est cmdline-level → nécessite reboot pour activer ET pour
+# désactiver. Trop de friction pour un cas d'usage légitime
+# ponctuel (présenter avec un clicker BT, dépanner un accessoire).
+# La défense baseline reste : aucun service BT ne tourne sur un
+# poste Sécurix standard, pas d'annonce, pas de scan, pas de
+# pairing → surface d'attaque passive = zéro.
+#
+# CAVEAT IMPORTANT : brancher un dongle + activer les services
+# ré-expose la pile bluez à toutes les CVE listées ci-dessus. Voir
+# le body de la PR upstream pour les recommandations opérationnelles
+# (filtrage MAC, désactivation en mobilité, etc.).
+#
+# Accessoires cassés (à remplacer) :
+#
+#   * Claviers / souris BT     → USB / USB-C / Logitech Unifying (non-BT)
+#   * Casques / écouteurs BT   → jack 3.5mm / USB-C / DAC filaire
+#   * Transfert fichiers BT    → non applicable (AirDrop Linux n'existe pas)
+#   * Geolocalisation wifi-BT  → GeoClue fonctionne en wifi-only
+#   * Tethering téléphone BT   → USB-tether ou wifi-AP
+#
+# Le surcoût ~30-50€ pour des accessoires filaires est, en pratique,
+# négligeable face à la réduction de surface d'attaque d'une pile
+# entière du kernel.
+{
+  R15b = {
+    name = "R15b_DisableBluetooth";
+    anssiRef = "R15 – Désactiver les services non utilisés (Bluetooth)";
+    description = ''
+      Désactive complètement la pile Bluetooth (service userspace +
+      modules kernel). Bloque le chargement automatique même lors
+      du hotplug d'un dongle USB BT.
+    '';
+    severity = "reinforced";
+    category = "base";
+    tags = [ "bluetooth" ];
+
+    config =
+      { lib, config, ... }:
+      {
+        assertions = [
+          {
+            assertion = !(config.hardware.bluetooth.enable or false);
+            message = ''
+              ANSSI R15b (durcissement Bluetooth Sécurix) exige
+              `hardware.bluetooth.enable = false`.
+
+              Le Bluetooth a un historique récurrent de CVE kernel
+              exploitables à distance (BlueBorne, BleedingTooth,
+              BrakTooth, BLUFFS, …). Sur un poste qui voyage hors
+              des environnements contrôlés, la surface d'attaque
+              l'emporte sur le confort des périphériques sans fil.
+
+              Pour autoriser le Bluetooth quand même, exclure cette
+              règle : `security.anssi.excludes = [ "bluetooth" ]` —
+              ET retirer les modules bluez de
+              `boot.blacklistedKernelModules` dans votre configuration.
+            '';
+          }
+          {
+            assertion = !(config.services.blueman.enable or false);
+            message = ''
+              ANSSI R15b exige `services.blueman.enable = false`.
+              À exclure via `security.anssi.excludes = [ "bluetooth" ]`.
+            '';
+          }
+        ];
+
+        # Met les options NixOS natives à false. Utilise mkDefault
+        # pour qu'un utilisateur qui exclut explicitement cette
+        # règle puisse les réactiver sans plomberie force-override.
+        # Les modules kernel bluez NE SONT PAS blacklistés
+        # délibérément — un dongle USB peut encore être branché et
+        # reconnu par le kernel. Sans le service userspace
+        # (bluetoothd / blueman), rien ne parle BT en pratique,
+        # donc un module kernel seul n'est pas une surface d'attaque
+        # active ; elle ne le redevient que quand l'opérateur exclut
+        # explicitement cette règle et réactive le service.
+        hardware.bluetooth.enable = lib.mkDefault false;
+        services.blueman.enable = lib.mkDefault false;
+      };
+
+    checkScript =
+      pkgs:
+      pkgs.writeShellScript "check-R15b" ''
+        status=0
+        # Aucun service userspace bluetooth actif (la seule couche
+        # appliquée par R15b — les modules kernel sont autorisés à
+        # se charger, l'essentiel est que le niveau service reste
+        # inactif).
+        if ${pkgs.systemd}/bin/systemctl is-active bluetooth.service 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q '^active'; then
+          echo "FAIL: bluetooth.service est actif"
+          status=1
+        fi
+        if ${pkgs.systemd}/bin/systemctl is-active blueman-mechanism.service 2>/dev/null | ${pkgs.gnugrep}/bin/grep -q '^active'; then
+          echo "FAIL: blueman-mechanism.service est actif"
+          status=1
+        fi
+        # Informationnel : présence des modules kernel.
+        if ${pkgs.kmod}/bin/lsmod 2>/dev/null | ${pkgs.gnugrep}/bin/grep -qE '^(bluetooth|btusb)'; then
+          echo "INFO: modules kernel bluez CHARGÉS (dongle branché ou contrôleur built-in détecté)"
+          echo "  -> le userspace est désactivé, mais activer le service en excluant la règle"
+          echo "     monterait BT sans reboot. Vérifier que c'est intentionnel."
+        fi
+        if [ $status -eq 0 ]; then
+          echo "PASS: userspace Bluetooth désactivé (les modules kernel peuvent être chargés mais ne sont pas consommés)"
+        fi
+        exit $status
+      '';
+  };
+}

--- a/modules/anssi/ruleset.nix
+++ b/modules/anssi/ruleset.nix
@@ -16,6 +16,7 @@ loadRules [
   # ./selinux.nix
   # ./journaling.nix
   # ./runtime-minimization.nix
+  ./no-bluetooth.nix
   # ./hardening.nix
   # ./nss-hardening.nix
   # ./integrity.nix


### PR DESCRIPTION
anssi : R15b — désactivation de la pile Bluetooth userspace (CIS 3.1.4)

Ferme la lacune CIS 3.1.4 identifiée dans l'audit de sécurité
Sécurix. Désactive la pile *userspace* Bluetooth (démon + service
management) sur chaque poste Sécurix. Les modules kernel restent
libres de se charger — un dongle peut toujours être branché
temporairement si l'opérateur opt-out explicitement de cette règle.

C'est délibérément une posture plus douce que l'approche
« blacklist complet des modules bluez » : la baseline de sécurité
(aucun service actif, pas de scan, pas d'annonce, pas de pairing)
est atteinte au niveau service ; la porte kernel reste ouverte, de
sorte que ré-activer BT est une opération `nixos-rebuild` plutôt
qu'un reboot.

## Historique CVE fermé par cette baseline

Bluetooth sur Linux a eu une cadence annuelle de vulnérabilités
exploitables à distance depuis 2017 :

  2017  BlueBorne         8 CVE, RCE sans pairing, sans interaction user
  2019  KNOB              forçage PIN 1 octet → MITM complet
  2020  BIAS              impersonation d'un pair appairé
  2020  BleedingTooth     RCE L2CAP kernel, CVSS 8.3 (CVE-2020-12351/12352)
  2021  BrakTooth         16 CVE, crash + potentiel RCE
  2022  DirtyBT           plusieurs CVE dans btusb + HCI
  2023  BLUFFS            6 CVE, MITM de session post-pairing
  2024  DoS Flipper-Zero  boot loop kernel sur scan BT agressif

Toutes exigent un service Bluetooth qui tourne (bluetoothd) sur la
cible pour consommer les paquets forgés. Avec le service désactivé,
un dongle ou un contrôleur built-in est en pratique dormant — le
module charge, `hci0` apparaît dans sysfs, mais aucun démon ne
consomme les événements, pas d'annonce, pas de tentative de
pairing réussie.

## Ce que cette règle applique

Deux couches, toutes deux au niveau service :

### Couche 1 — options NixOS

  hardware.bluetooth.enable = false      # mkDefault
  services.blueman.enable   = false      # mkDefault

### Couche 2 — assertion au build

Toute configuration utilisateur qui réactive
`hardware.bluetooth.enable` ou `services.blueman.enable` fait
échouer `nixos-rebuild` avec un message d'erreur explicite pointant
vers `security.anssi.excludes`. Pas de réactivation silencieuse,
même depuis un module tiers.

## Ce que cette règle NE fait pas délibérément

### Blacklist des modules kernel

Un draft précédent de ce PR blacklistait les modules kernel bluez
(bluetooth, btusb, btrtl, etc.) via
`boot.blacklistedKernelModules`. Cette approche a un coût
opérationnel précis : ré-activer Bluetooth exige un reboot (la
cmdline kernel ne prend effet qu'au boot).

Pour les postes d'administration qui ont besoin occasionnellement
d'un dongle BT (présentation avec clicker BT, dépannage d'un
accessoire), la friction reboot est trop forte. La posture
service-level préserve la défense en profondeur (zéro daemon
actif out-of-box) tout en laissant une porte de sortie
raisonnable.

### Alternatives pour les accessoires

Pour ne pas se retrouver bloqué, remplacer par équivalent filaire :

  * claviers / souris BT     → USB / USB-C / Logitech Unifying
  * casques / écouteurs BT   → jack 3.5 mm / USB-C / DAC filaire
  * transfert fichiers BT    → n/a (pas d'AirDrop Linux)
  * géoloc wifi-BT           → GeoClue marche en wifi seul
  * tethering BT             → USB-tether ou wifi-AP

Le surcoût ~30-50 € pour des accessoires filaires est négligeable
face à la réduction de surface d'attaque d'une pile kernel
entière.

## Validation

Avec `security.anssi.enable = true` + `level >= reinforced` dans
`tests.full` :

  $ systemctl is-enabled bluetooth.service
  disabled

  $ systemctl is-enabled blueman-mechanism.service
  disabled

  $ anssi-nixos-compliance-check | grep R15b
  PASS: userspace Bluetooth désactivé (les modules kernel peuvent être chargés mais ne sont pas consommés)

Refs : ANSSI R15 — Désactiver les services non utilisés
Refs : CIS Distribution-Independent Linux Benchmark 3.1.4
Refs : audit report Sécurix — Wave Q1
