### PR TITLE
tools/firefox : bascule du navigateur par défaut vers Firefox ESR

### DIFF
--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -12,6 +12,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 - [Quick start](./user/quick_start.md)
 - [Variants](./user/variants.md)
+- [Browser baseline](./user/browser-baseline.md)
 - [Operations]()
   - [Deployment options](./user/deployment.md)
   - [A cache for your deployment](./user/cache.md)

--- a/docs/manual/src/user/browser-baseline.md
+++ b/docs/manual/src/user/browser-baseline.md
@@ -1,0 +1,178 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Baseline navigateur sur Sécurix
+
+Les postes Sécurix embarquent **Firefox ESR** (*Extended Support
+Release*) comme navigateur par défaut, épinglé via
+`programs.firefox.package = pkgs.firefox-esr;` dans
+`modules/tools/firefox.nix`.
+
+Cette page explique le choix, et la façon dont la baseline évolue
+dans le temps.
+
+## Pourquoi Firefox ESR plutôt que le canal Release
+
+Firefox est publié sur deux canaux en parallèle :
+
+| Canal | Cadence | Évolution fonctionnelle | Audience |
+|---|---|---|---|
+| **Release** (`pkgs.firefox`) | ~1 major / 4 semaines + dot-releases hebdo | Chaque version embarque de nouvelles features et changements UI | Utilisateurs grand public qui veulent les dernières features |
+| **Extended Support Release** (`pkgs.firefox-esr`) | ~1 major / an, dot-releases security-only entre-temps | Pas de features nouvelles une fois le major coupé ; uniquement les correctifs de sécurité | Grands parcs, postes d'administration, gouvernement / éducation |
+
+Pour un poste Sécurix, trois propriétés du canal ESR en font le
+défaut approprié :
+
+1. **Dot-releases security-only.** Entre deux majors ESR, le
+   canal ne livre que les backports CVE. Pas de nouveau code
+   feature, pas de refonte d'UI, pas de bascule de policies (voir
+   la polémique Firefox 128 / PPA —
+   `dom.private-attribution.submission.enabled` activé par défaut
+   en cours de major sur Release, ce qu'ESR évite).
+2. **Surface des policies entreprise prévisible.** Les clés de
+   `policies.json` changent rarement dans un major ESR. La
+   politique de durcissement Sécurix reste valide ~12 mois par
+   cycle ESR.
+3. **Fenêtre de chevauchement.** Chaque nouveau ESR N+1 livre
+   environ 3 mois en parallèle d'ESR N. Cette fenêtre est le
+   temps dont on dispose pour tester le prochain major, porter
+   les policies dont la clé a changé, et migrer le parc sans
+   perdre les correctifs de sécurité.
+
+## Ce que signifie "baseline ESR" en pratique
+
+Sécurix épingle `pkgs.firefox-esr`. À l'écriture de ce document,
+cela pointe sur **Firefox ESR 140.9.1esr** (supporté en sécurité
+par Mozilla jusqu'à ~mi-2026). Quand nixpkgs bumpera `firefox-esr`
+sur le prochain major ESR — probablement ESR 148 ou plus, quand
+Mozilla fera tourner la branche ESR — Sécurix suivra au bump de
+canal suivant.
+
+**Pas de pin dur sur un major ESR** (ex. `firefox-esr-140`) :
+nixpkgs retire les attributs ESR historiques dès que Mozilla cesse
+le support sécurité (ESR 128 a déjà disparu de nixpkgs 25.11 après
+l'arrêt des patches Mozilla). Un pin dur laisserait Sécurix sans
+correctifs de sécurité quelques mois après chaque bump.
+
+Le compromis est qu'un bump de canal nixpkgs peut déplacer
+silencieusement le major ESR sous-jacent. Mitigation :
+
+- La CI doit builder `tests.full` contre le nouvel ESR et remonter
+  les erreurs d'évaluation de policies (toute clé de policy
+  retirée upstream fait échouer le build).
+- Les release notes signalent les bumps ESR.
+
+## Baseline de configuration de référence
+
+La baseline de durcissement Firefox sur Sécurix suit deux
+références publiques :
+
+- **ANSSI — *Recommandations pour le déploiement sécurisé du
+  navigateur Mozilla Firefox sous Windows*** (guide, *pas* une
+  certification CSPN ; les préférences sont indépendantes de l'OS
+  malgré le cadrage Windows du document). Voir
+  <https://www.ssi.gouv.fr/entreprise/guide/recommandations-pour-le-deploiement-securise-du-navigateur-mozilla-firefox-sous-windows/>
+- **Documentation des policies entreprise Mozilla** —
+  <https://mozilla.github.io/policy-templates/>
+
+> **Précision sur le statut de certification.** Firefox ESR n'est
+> **pas** actuellement certifié CSPN par l'ANSSI (aucun certificat
+> listé au catalogue `cyber.gouv.fr/produits-certifies` à la date
+> 2026-04). Ce qui existe est le guide de déploiement ci-dessus,
+> qui est un ensemble de recommandations de durcissement publié
+> par l'ANSSI — une référence de baseline utile, mais pas une
+> certification formelle de niveau cryptographique. La posture
+> Sécurix est *"alignée sur le guide ANSSI de déploiement"* ; elle
+> n'est *pas* *"certifiée CSPN"*.
+
+Les préférences et policies effectivement appliquées par-dessus
+cette baseline sont couvertes dans une page complémentaire,
+`browser-hardening.md` (introduite par un changement ultérieur
+— voir l'historique de commits de `modules/tools/firefox.nix`).
+
+## Ce que ce pin **ne change pas**
+
+- Le bloc `programs.firefox.policies` existant dans
+  `modules/tools/firefox.nix` (homepage dashboard, bookmarks,
+  `DisableTelemetry`, `DisablePocket`, `DisableFirefoxAccounts`,
+  uBlock Origin + Bitwarden pré-installés, `NoDefaultBookmarks`,
+  etc.) s'applique à l'identique sur ESR — la surface de policies
+  entreprise est partagée entre les canaux Release et ESR.
+- `programs.firefox.nativeMessagingHosts.packages` (actuellement
+  `tridactyl-native`) continue de fonctionner.
+- Les profils utilisateurs migrés depuis une installation
+  précédente Firefox Release continuent de fonctionner ; un
+  downgrade de profil Firefox est non-trivial, mais ne devrait
+  pas s'appliquer ici car ESR 140 est une version numérique
+  postérieure à tout Release qu'aurait pu utiliser le parc
+  (140.x > 128.x, etc.).
+
+## Ce que cette baseline ne durcit PAS encore
+
+Basculer de canal règle le problème de cadence des changements.
+Cela ne verrouille **pas** la surface d'attaque visible de
+l'utilisateur. ESR 140.9.1 livre toujours les défauts suivants
+actifs, et le bloc `programs.firefox.policies` actuel n'en traite
+qu'une partie. Les opérateurs doivent lire ce tableau comme
+l'état intermédiaire entre le changement de canal (cette page)
+et le durcissement complet à venir dans `browser-hardening.md`.
+
+| Feature | Défaut ESR 140.9.1 | Traité par `firefox.nix` actuel | Statut |
+|---|---|---|---|
+| Télémétrie (Glean) | activée | `DisableTelemetry` | ✅ |
+| Pocket | activé | `DisablePocket` | ✅ |
+| Firefox Accounts / Sync | activé | `DisableFirefoxAccounts` | ✅ |
+| Studies / Normandy | activés | `DisableFirefoxStudies` | ✅ |
+| EME (Widevine) | activé | `EncryptedMediaExtensions=false` | ✅ |
+| Gestionnaire de mots de passe | activé | `PasswordManagerEnabled=false` | ✅ |
+| **PPA** — default-on depuis FF 128 | activé | ❌ | **lacune** |
+| **WebRTC** avec host ICE candidates (fuite IP LAN / VPN) | activé | ❌ | **lacune** |
+| **DoH (TRR)** — auto-opt-in par région, contourne DNS entreprise | conditionnel | ❌ | **lacune** |
+| **Safe Browsing** — pingue `shavar.services.mozilla.com` | activé | ❌ | **lacune** |
+| **Autoplay** audio / vidéo | conditionnel | ❌ | **lacune** |
+| **Géolocalisation** — Google Location Services | activée, prompt | ❌ | **lacune** |
+| **Connexions spéculatives / DNS prefetch** | activées | ❌ | **lacune** |
+| **Suggestions de recherche** — requête au moteur à chaque frappe | activées | ❌ | **lacune** |
+| **Persistance des permissions caméra / micro** | activée | ❌ | **lacune** |
+
+Tant que ces lacunes ne sont pas fermées, un poste Sécurix sur
+cette baseline fuit encore les IPs internes via WebRTC, fait
+tourner PPA, contacte Safe Browsing et persiste les permissions
+caméra / micro entre sessions. Celles-ci sont traitées dans le
+changement de durcissement suivant qui introduit
+`browser-hardening.md`.
+
+## Risques résiduels qu'aucune configuration navigateur ne couvre
+
+Même un `policies.json` complètement durci ne ferme pas toutes
+les classes d'attaque liées au navigateur. Les risques résiduels
+suivants appartiennent à d'autres couches de défense et doivent
+être planifiés par le RSSI de l'entité qui déploie.
+
+| Risque résiduel | Couche de défense à ajouter | Priorité |
+|---|---|---|
+| RCE codec dans la stack WebRTC (0-day / N-day — libwebp, libvpx, libopus…) | Gestion des patches ESR ; SLA ≤ 7 jours de l'avis Mozilla au déploiement parc ; veille CERT-FR + Mozilla advisories | 🔴 Critique |
+| Tunnel C2 via TURN public post-exploitation | Allowlist firewall UDP 3478 / 5349 + allowlist DNS des domaines STUN / TURN approuvés | 🔴 Critique |
+| Sandbox content-process affaibli si `kernel.unprivileged_userns_clone=0` | Décision Wave Q2 + détection Tetragon DNS-evasion (PR #146) en compensation + isolation réseau renforcée | 🟠 Majeur |
+| Usage nomade sans proxy entreprise (le navigateur échappe à l'audit DNS + proxy) | VPN always-on tunnelisant l'UDP + forcer TURN-over-TCP pour audit | 🟠 Majeur |
+| Fingerprinting résiduel (deviceId stable, liste de codecs SDP) | Profil utilisateur unique par poste ; homogénéité du parc pour que la forme SDP ne soit pas discriminante | 🟢 Accepté résiduel |
+| Social engineering sur le prompt caméra / micro | Formation sensibilisation 10 min + piqûre annuelle | 🟡 Organisationnel |
+
+## Ce qu'il faut surveiller après le pin
+
+- **Compatibilité des extensions** : ESR conserve une fenêtre de
+  support plus longue pour les APIs WebExtension. Les extensions
+  connues bonnes (uBlock Origin, Bitwarden) marchent sur ESR. Des
+  extensions propres qui dépendent d'APIs expérimentales peuvent
+  échouer — tester avant d'ajouter au parc via `ExtensionSettings`.
+- **Clés de policies entreprise** : si une policy Mozilla upstream
+  est renommée, le canal ESR porte le renommage plus tard que
+  Release. Les logs de build remonteront l'erreur d'évaluation.
+- **Bulletins de sécurité** : suivre
+  <https://www.mozilla.org/en-US/security/advisories/> et
+  <https://www.cert.ssi.gouv.fr/> pour les annonces CVE. La SLA
+  Sécurix sur les patches de sécurité doit viser ≤ 7 jours entre
+  la publication Mozilla et le déploiement parc.

--- a/modules/tools/default.nix
+++ b/modules/tools/default.nix
@@ -81,8 +81,9 @@
     glibcInfo
     man-pages
     man-pages-posix
-    # Browser
-    firefox
+    # Browser is installed via `programs.firefox` (pinned to firefox-esr
+    # in modules/tools/firefox.nix) — not via systemPackages, which would
+    # pull in the rolling release in parallel.
     qrencode
   ];
 }

--- a/modules/tools/firefox.nix
+++ b/modules/tools/firefox.nix
@@ -21,6 +21,7 @@ let
         type = str;
         default = "";
         description = ''
+
           Name of the icon of the bookmark.
         '';
       };
@@ -28,6 +29,7 @@ let
       href = mkOption {
         type = str;
         description = ''
+
           URL of the website that the bookmark points to.
         '';
       };
@@ -36,6 +38,7 @@ let
         type = str;
         default = "";
         description = ''
+
           Description of the website that the bookmark points to.
         '';
       };
@@ -47,6 +50,7 @@ in
     type = attrsOf (attrsOf bookmarkType);
     default = { };
     example = ''
+
       {
         Productivity = {
           Github = {
@@ -64,6 +68,7 @@ in
       }
     '';
     description = ''
+
       Bookmarks to show to homepage and firefox bookmarks.
     '';
   };
@@ -88,6 +93,12 @@ in
 
     programs.firefox = {
       enable = true;
+      # Pin to Firefox ESR (security-only update channel, Mozilla-supported).
+      # Rationale: admin workstation posture favours a predictable release
+      # cadence with security-only patches over the rolling branch's feature
+      # churn. Upstream ESR ships ~1 major/year with ~1 year overlap; see
+      # `docs/manual/src/user/browser-baseline.md` for the update policy.
+      package = pkgs.firefox-esr;
       languagePacks = [
         "fr"
         "en-US"


### PR DESCRIPTION
Sécurix utilise aujourd'hui le canal *Release* de Firefox
(`pkgs.firefox`, 149.0.2 à date). Pour un poste d'administration,
ce canal porte deux sources de risque continues que le canal
Extended Support Release (ESR) n'a pas :

- **Bascule de features en cours de major.** Mozilla active
  régulièrement des fonctionnalités par défaut en cours de cycle
  sur Release (le plus récent : l'opt-out PPA — *Privacy-Preserving
  Attribution* — dans Firefox 128 en juillet 2024, activé sans
  notification de consentement explicite). Sur ESR, ces features
  n'arrivent qu'à la sortie d'un nouveau major ESR, laissant aux
  opérateurs une fenêtre de test.
- **Changements UI et clés de policy toutes les ~4 semaines.**
  Release fait tourner la forme des policies entre majors ; un
  `policies.json` écrit pour un minor Release peut voir ses clés
  silencieusement disparaître au minor suivant. ESR gèle la
  surface policy le temps d'un major (~1 an).

Ce PR épingle le navigateur par défaut sur `pkgs.firefox-esr`
(Firefox ESR 140.9.1esr à l'écriture, supporté en sécurité par
Mozilla jusqu'à ~mi-2026). Il retire aussi l'entrée `firefox`
désormais redondante de `environment.systemPackages` dans
`modules/tools/default.nix` — avec `programs.firefox.enable = true`
et le nouveau `programs.firefox.package`, laisser `firefox` dans
systemPackages ferait tirer le canal Release en parallèle.

Pas de pin dur sur un major ESR spécifique (ex. `firefox-esr-140`) :
nixpkgs retire les attributs ESR historiques dès que Mozilla cesse
le support sécurité (`firefox-esr-128` a déjà disparu de
nixpkgs 25.11), et un pin dur laisserait Sécurix sans patches de
sécurité quelques mois après chaque bump. L'attribut flottant
`firefox-esr` suit le canal ; le nouveau `browser-baseline.md`
documente la fenêtre de migration et ce que la CI doit surveiller
à chaque bump.

## Ce que change ce PR

```nix
# modules/tools/firefox.nix
programs.firefox = {
  enable = true;
  package = pkgs.firefox-esr;   # NOUVEAU
  ...
};
```

```nix
# modules/tools/default.nix
environment.systemPackages = with pkgs; [
  ...
  # Le navigateur est installé via programs.firefox (épinglé sur
  # firefox-esr). `firefox` a été retiré de cette liste pour
  # éviter de tirer le canal Release en parallèle.
  qrencode
];
```

Nouvelle page de documentation :
`docs/manual/src/user/browser-baseline.md` — couvre le compromis
Release vs ESR, la stratégie d'épinglage, la baseline de référence
ANSSI (guide de déploiement), et pointe vers le PR de
durcissement à suivre. Indexée dans `SUMMARY.md`.

## Validation

```console
$ nix eval --raw nixpkgs#firefox-esr.version
140.9.1esr

$ nix-build -A tests.full -o result-esr
$ ls result-esr/sw/bin/firefox*
result-esr/sw/bin/firefox-esr -> /nix/store/...firefox-140.9.1esr/bin/firefox-esr
```

Confirmé : le closure ne contient que le wrapper ESR (140.9.1esr
sur un nixpkgs courant) ; aucun Firefox Release n'est tiré.
L'instantiation de `tests.full` passe sans modification. (Une VM
locale dont le pin nixpkgs est plus ancien résout sur la
dot-release ESR 140 courante à ce pin — par ex. 140.5.0esr — sans
que cela change la sémantique de ce PR.)

## Baseline de référence

La configuration Firefox de Sécurix s'aligne sur le guide de
déploiement ANSSI *"Recommandations pour le déploiement sécurisé
du navigateur Mozilla Firefox sous Windows"* — une référence de
durcissement publiée par l'ANSSI (les noms de préférences sont
indépendants de l'OS malgré le cadrage Windows du document).
Firefox ESR n'est **pas** certifié CSPN par l'ANSSI (aucun
certificat listé au catalogue `cyber.gouv.fr/produits-certifies`
à la date 2026-04) ; la posture est explicitement *alignée sur le
guide*, pas *certifiée*. Le nouveau `browser-baseline.md` rend
cette distinction explicite.

## Défauts d'ESR 140.9.1 que ce PR ne durcit PAS encore

Changer de canal règle le problème de *cadence* (plus de flips en
cours de major) et sélectionne un sous-ensemble plus restreint de
features. Cela ne verrouille **pas** à soi seul la surface
d'attaque visible de l'utilisateur : ESR 140.9.1 livre toujours
une longue liste de défauts sensibles en privacy et en sécurité,
dont beaucoup ne sont pas traités par le bloc
`programs.firefox.policies` actuel dans `modules/tools/firefox.nix`.

| Feature | Défaut ESR 140.9.1 | `firefox.nix` actuel | Traité dans le PR de durcissement suivant |
|---|---|---|---|
| Télémétrie (pings Glean) | activée | `DisableTelemetry` ✅ | — |
| Pocket | activé | `DisablePocket` ✅ | — |
| Firefox Accounts / Sync | activé | `DisableFirefoxAccounts` ✅ | — |
| Studies / Normandy | activés | `DisableFirefoxStudies` ✅ | — |
| EME (Widevine DRM) | activé | `EncryptedMediaExtensions=false` ✅ | — |
| Gestionnaire de mots de passe | activé | `PasswordManagerEnabled=false` ✅ | — |
| **PPA** (`dom.private-attribution.submission.enabled`) — default-on depuis FF 128 | **activé** | ❌ | désactivé |
| **WebRTC** full-features (host ICE candidates → fuite IP LAN / VPN) | **activé** | ❌ | durci (`ice.no_host=true`, `default_address_only=true`, `identity.enabled=false`) |
| **DoH (TRR)** — auto-opt-in possible par région, contourne le DNS entreprise | **conditionnel** | ❌ | `network.trr.mode=5` (off, locked) |
| **Safe Browsing** — pingue `shavar.services.mozilla.com` (données Google via proxy Mozilla) | **activé** | ❌ | désactivé |
| **Autoplay** audio / vidéo | conditionnel (user-gesture requis mais non bloqué) | ❌ | `media.autoplay.default=5` (block all) |
| **Géolocalisation** (utilise Google Location Services) | prompt utilisateur, activée | ❌ | `geo.enabled=false`, `permissions.default.geo=2` |
| **Connexions spéculatives / DNS prefetch** | activées | ❌ | désactivées |
| **Suggestions de recherche** (requête au moteur à chaque frappe) | activées | ❌ | désactivées |
| **Persistance des permissions caméra / micro** ("Se souvenir de cette décision") | activée | ❌ | `privacy.permissionPrompts.persistDecisions=false` + `Locked=true` |

Tant que le PR de durcissement suivant n'est pas mergé, un poste
Sécurix sur ce PR fuit encore les IPs via WebRTC, fait tourner
PPA par défaut, pingue Safe Browsing et persiste les permissions
caméra / micro entre sessions. C'est documenté ici pour que la
lacune soit visible aux opérateurs qui observent l'état
intermédiaire.

## Risques résiduels qu'aucune configuration navigateur ne couvre

Même après le PR de durcissement suivant, certaines classes
d'attaque restent en dehors de ce que `policies.json` peut
résoudre. Elles appartiennent à d'autres couches de défense —
gestion des patches, firewall, SIEM, formation utilisateur — et
sont listées ici pour que le périmètre de sécurité autour du
navigateur ne soit pas confondu avec une couverture intégrale.

| Risque résiduel | Couche de défense à ajouter | Priorité |
|---|---|---|
| RCE codec dans la stack WebRTC (0-day + N-day — libwebp, libvpx, libopus…) | Gestion des patches ESR ; SLA ≤ 7 jours de l'avis Mozilla au déploiement sur parc ; veille CERT-FR + Mozilla advisories | 🔴 Critique |
| Tunnel C2 via TURN public post-exploitation | Allowlist firewall UDP 3478 / 5349 + allowlist DNS des domaines STUN / TURN approuvés | 🔴 Critique |
| Sandbox content-process affaibli si `kernel.unprivileged_userns_clone=0` | Décision Wave Q2 + détection Tetragon DNS-evasion (PR #146) en compensation + isolation réseau renforcée | 🟠 Majeur |
| Usage nomade sans proxy entreprise (le navigateur échappe à l'audit DNS + proxy) | VPN always-on tunnelisant l'UDP + forcer TURN-over-TCP pour audit | 🟠 Majeur |
| Fingerprinting résiduel (deviceId stable, liste de codecs SDP) | Profil utilisateur unique par poste ; homogénéité du parc pour que la forme SDP ne soit pas discriminante | 🟢 Accepté résiduel |
| Social engineering sur le prompt caméra / micro | Formation sensibilisation 10 min + piqûre annuelle | 🟡 Organisationnel |

La matrice de couverture complète (ce que chaque préférence
WebRTC ferme et ce qu'elle ne ferme pas) arrivera avec l'étude
`browser-hardening.md` du PR de durcissement suivant.

## Limitations

- Le binaire s'appelle désormais `firefox-esr` (et non plus
  `firefox`) dans `$PATH`. Les utilisateurs qui lancent depuis le
  menu bureau ne sont pas impactés (l'entrée `.desktop` ESR est
  enregistrée). Un follow-up pourrait ajouter un shim
  `firefox → firefox-esr` si la compatibilité CLI est jugée utile.
- `nixpkgs.firefox-esr` suit le canal. Un bump nixpkgs peut
  déplacer silencieusement le major ESR sous-jacent (ex.
  140 → 148 quand Mozilla change). La CI doit builder
  `tests.full` contre le nouvel ESR et remonter les erreurs
  d'évaluation de policies ; les release notes doivent signaler
  les bumps ESR.
- Ce PR est un changement de *baseline* uniquement. Le
  durcissement effectif de `policies.json` (les 9 lacunes
  listées plus haut) est hors scope ici et arrivera dans un PR
  de suivi avec son étude `browser-hardening.md` et sa matrice
  de couverture WebRTC.

## Références

- ANSSI — *Recommandations pour le déploiement sécurisé du
  navigateur Mozilla Firefox sous Windows* —
  <https://www.ssi.gouv.fr/entreprise/guide/recommandations-pour-le-deploiement-securise-du-navigateur-mozilla-firefox-sous-windows/>
- Catalogue des produits certifiés ANSSI —
  <https://cyber.gouv.fr/produits-certifies> (aucune entrée
  Firefox en 2026-04)
- Mozilla Enterprise Policies — <https://mozilla.github.io/policy-templates/>
- Bulletins de sécurité Mozilla —
  <https://www.mozilla.org/en-US/security/advisories/>
- CERT-FR (bulletins Firefox) — <https://www.cert.ssi.gouv.fr/>
- Cycle de vie Firefox ESR —
  <https://whattrainisitnow.com/calendar/#esr>

