### PR TITLE
tools/firefox : durcissement policies (WebRTC, DoH, PPA, permissions…)

### DIFF
--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -12,6 +12,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 - [Quick start](./user/quick_start.md)
 - [Variants](./user/variants.md)
+- [Browser baseline](./user/browser-baseline.md)
 - [Operations]()
   - [Deployment options](./user/deployment.md)
   - [A cache for your deployment](./user/cache.md)

--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -13,6 +13,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - [Quick start](./user/quick_start.md)
 - [Variants](./user/variants.md)
 - [Browser baseline](./user/browser-baseline.md)
+- [Browser hardening](./user/browser-hardening.md)
 - [Operations]()
   - [Deployment options](./user/deployment.md)
   - [A cache for your deployment](./user/cache.md)

--- a/docs/manual/src/user/browser-baseline.md
+++ b/docs/manual/src/user/browser-baseline.md
@@ -1,0 +1,178 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Baseline navigateur sur Sécurix
+
+Les postes Sécurix embarquent **Firefox ESR** (*Extended Support
+Release*) comme navigateur par défaut, épinglé via
+`programs.firefox.package = pkgs.firefox-esr;` dans
+`modules/tools/firefox.nix`.
+
+Cette page explique le choix, et la façon dont la baseline évolue
+dans le temps.
+
+## Pourquoi Firefox ESR plutôt que le canal Release
+
+Firefox est publié sur deux canaux en parallèle :
+
+| Canal | Cadence | Évolution fonctionnelle | Audience |
+|---|---|---|---|
+| **Release** (`pkgs.firefox`) | ~1 major / 4 semaines + dot-releases hebdo | Chaque version embarque de nouvelles features et changements UI | Utilisateurs grand public qui veulent les dernières features |
+| **Extended Support Release** (`pkgs.firefox-esr`) | ~1 major / an, dot-releases security-only entre-temps | Pas de features nouvelles une fois le major coupé ; uniquement les correctifs de sécurité | Grands parcs, postes d'administration, gouvernement / éducation |
+
+Pour un poste Sécurix, trois propriétés du canal ESR en font le
+défaut approprié :
+
+1. **Dot-releases security-only.** Entre deux majors ESR, le
+   canal ne livre que les backports CVE. Pas de nouveau code
+   feature, pas de refonte d'UI, pas de bascule de policies (voir
+   la polémique Firefox 128 / PPA —
+   `dom.private-attribution.submission.enabled` activé par défaut
+   en cours de major sur Release, ce qu'ESR évite).
+2. **Surface des policies entreprise prévisible.** Les clés de
+   `policies.json` changent rarement dans un major ESR. La
+   politique de durcissement Sécurix reste valide ~12 mois par
+   cycle ESR.
+3. **Fenêtre de chevauchement.** Chaque nouveau ESR N+1 livre
+   environ 3 mois en parallèle d'ESR N. Cette fenêtre est le
+   temps dont on dispose pour tester le prochain major, porter
+   les policies dont la clé a changé, et migrer le parc sans
+   perdre les correctifs de sécurité.
+
+## Ce que signifie "baseline ESR" en pratique
+
+Sécurix épingle `pkgs.firefox-esr`. À l'écriture de ce document,
+cela pointe sur **Firefox ESR 140.9.1esr** (supporté en sécurité
+par Mozilla jusqu'à ~mi-2026). Quand nixpkgs bumpera `firefox-esr`
+sur le prochain major ESR — probablement ESR 148 ou plus, quand
+Mozilla fera tourner la branche ESR — Sécurix suivra au bump de
+canal suivant.
+
+**Pas de pin dur sur un major ESR** (ex. `firefox-esr-140`) :
+nixpkgs retire les attributs ESR historiques dès que Mozilla cesse
+le support sécurité (ESR 128 a déjà disparu de nixpkgs 25.11 après
+l'arrêt des patches Mozilla). Un pin dur laisserait Sécurix sans
+correctifs de sécurité quelques mois après chaque bump.
+
+Le compromis est qu'un bump de canal nixpkgs peut déplacer
+silencieusement le major ESR sous-jacent. Mitigation :
+
+- La CI doit builder `tests.full` contre le nouvel ESR et remonter
+  les erreurs d'évaluation de policies (toute clé de policy
+  retirée upstream fait échouer le build).
+- Les release notes signalent les bumps ESR.
+
+## Baseline de configuration de référence
+
+La baseline de durcissement Firefox sur Sécurix suit deux
+références publiques :
+
+- **ANSSI — *Recommandations pour le déploiement sécurisé du
+  navigateur Mozilla Firefox sous Windows*** (guide, *pas* une
+  certification CSPN ; les préférences sont indépendantes de l'OS
+  malgré le cadrage Windows du document). Voir
+  <https://www.ssi.gouv.fr/entreprise/guide/recommandations-pour-le-deploiement-securise-du-navigateur-mozilla-firefox-sous-windows/>
+- **Documentation des policies entreprise Mozilla** —
+  <https://mozilla.github.io/policy-templates/>
+
+> **Précision sur le statut de certification.** Firefox ESR n'est
+> **pas** actuellement certifié CSPN par l'ANSSI (aucun certificat
+> listé au catalogue `cyber.gouv.fr/produits-certifies` à la date
+> 2026-04). Ce qui existe est le guide de déploiement ci-dessus,
+> qui est un ensemble de recommandations de durcissement publié
+> par l'ANSSI — une référence de baseline utile, mais pas une
+> certification formelle de niveau cryptographique. La posture
+> Sécurix est *"alignée sur le guide ANSSI de déploiement"* ; elle
+> n'est *pas* *"certifiée CSPN"*.
+
+Les préférences et policies effectivement appliquées par-dessus
+cette baseline sont couvertes dans une page complémentaire,
+`browser-hardening.md` (introduite par un changement ultérieur
+— voir l'historique de commits de `modules/tools/firefox.nix`).
+
+## Ce que ce pin **ne change pas**
+
+- Le bloc `programs.firefox.policies` existant dans
+  `modules/tools/firefox.nix` (homepage dashboard, bookmarks,
+  `DisableTelemetry`, `DisablePocket`, `DisableFirefoxAccounts`,
+  uBlock Origin + Bitwarden pré-installés, `NoDefaultBookmarks`,
+  etc.) s'applique à l'identique sur ESR — la surface de policies
+  entreprise est partagée entre les canaux Release et ESR.
+- `programs.firefox.nativeMessagingHosts.packages` (actuellement
+  `tridactyl-native`) continue de fonctionner.
+- Les profils utilisateurs migrés depuis une installation
+  précédente Firefox Release continuent de fonctionner ; un
+  downgrade de profil Firefox est non-trivial, mais ne devrait
+  pas s'appliquer ici car ESR 140 est une version numérique
+  postérieure à tout Release qu'aurait pu utiliser le parc
+  (140.x > 128.x, etc.).
+
+## Ce que cette baseline ne durcit PAS encore
+
+Basculer de canal règle le problème de cadence des changements.
+Cela ne verrouille **pas** la surface d'attaque visible de
+l'utilisateur. ESR 140.9.1 livre toujours les défauts suivants
+actifs, et le bloc `programs.firefox.policies` actuel n'en traite
+qu'une partie. Les opérateurs doivent lire ce tableau comme
+l'état intermédiaire entre le changement de canal (cette page)
+et le durcissement complet à venir dans `browser-hardening.md`.
+
+| Feature | Défaut ESR 140.9.1 | Traité par `firefox.nix` actuel | Statut |
+|---|---|---|---|
+| Télémétrie (Glean) | activée | `DisableTelemetry` | ✅ |
+| Pocket | activé | `DisablePocket` | ✅ |
+| Firefox Accounts / Sync | activé | `DisableFirefoxAccounts` | ✅ |
+| Studies / Normandy | activés | `DisableFirefoxStudies` | ✅ |
+| EME (Widevine) | activé | `EncryptedMediaExtensions=false` | ✅ |
+| Gestionnaire de mots de passe | activé | `PasswordManagerEnabled=false` | ✅ |
+| **PPA** — default-on depuis FF 128 | activé | ❌ | **lacune** |
+| **WebRTC** avec host ICE candidates (fuite IP LAN / VPN) | activé | ❌ | **lacune** |
+| **DoH (TRR)** — auto-opt-in par région, contourne DNS entreprise | conditionnel | ❌ | **lacune** |
+| **Safe Browsing** — pingue `shavar.services.mozilla.com` | activé | ❌ | **lacune** |
+| **Autoplay** audio / vidéo | conditionnel | ❌ | **lacune** |
+| **Géolocalisation** — Google Location Services | activée, prompt | ❌ | **lacune** |
+| **Connexions spéculatives / DNS prefetch** | activées | ❌ | **lacune** |
+| **Suggestions de recherche** — requête au moteur à chaque frappe | activées | ❌ | **lacune** |
+| **Persistance des permissions caméra / micro** | activée | ❌ | **lacune** |
+
+Tant que ces lacunes ne sont pas fermées, un poste Sécurix sur
+cette baseline fuit encore les IPs internes via WebRTC, fait
+tourner PPA, contacte Safe Browsing et persiste les permissions
+caméra / micro entre sessions. Celles-ci sont traitées dans le
+changement de durcissement suivant qui introduit
+`browser-hardening.md`.
+
+## Risques résiduels qu'aucune configuration navigateur ne couvre
+
+Même un `policies.json` complètement durci ne ferme pas toutes
+les classes d'attaque liées au navigateur. Les risques résiduels
+suivants appartiennent à d'autres couches de défense et doivent
+être planifiés par le RSSI de l'entité qui déploie.
+
+| Risque résiduel | Couche de défense à ajouter | Priorité |
+|---|---|---|
+| RCE codec dans la stack WebRTC (0-day / N-day — libwebp, libvpx, libopus…) | Gestion des patches ESR ; SLA ≤ 7 jours de l'avis Mozilla au déploiement parc ; veille CERT-FR + Mozilla advisories | 🔴 Critique |
+| Tunnel C2 via TURN public post-exploitation | Allowlist firewall UDP 3478 / 5349 + allowlist DNS des domaines STUN / TURN approuvés | 🔴 Critique |
+| Sandbox content-process affaibli si `kernel.unprivileged_userns_clone=0` | Décision Wave Q2 + détection Tetragon DNS-evasion (PR #146) en compensation + isolation réseau renforcée | 🟠 Majeur |
+| Usage nomade sans proxy entreprise (le navigateur échappe à l'audit DNS + proxy) | VPN always-on tunnelisant l'UDP + forcer TURN-over-TCP pour audit | 🟠 Majeur |
+| Fingerprinting résiduel (deviceId stable, liste de codecs SDP) | Profil utilisateur unique par poste ; homogénéité du parc pour que la forme SDP ne soit pas discriminante | 🟢 Accepté résiduel |
+| Social engineering sur le prompt caméra / micro | Formation sensibilisation 10 min + piqûre annuelle | 🟡 Organisationnel |
+
+## Ce qu'il faut surveiller après le pin
+
+- **Compatibilité des extensions** : ESR conserve une fenêtre de
+  support plus longue pour les APIs WebExtension. Les extensions
+  connues bonnes (uBlock Origin, Bitwarden) marchent sur ESR. Des
+  extensions propres qui dépendent d'APIs expérimentales peuvent
+  échouer — tester avant d'ajouter au parc via `ExtensionSettings`.
+- **Clés de policies entreprise** : si une policy Mozilla upstream
+  est renommée, le canal ESR porte le renommage plus tard que
+  Release. Les logs de build remonteront l'erreur d'évaluation.
+- **Bulletins de sécurité** : suivre
+  <https://www.mozilla.org/en-US/security/advisories/> et
+  <https://www.cert.ssi.gouv.fr/> pour les annonces CVE. La SLA
+  Sécurix sur les patches de sécurité doit viser ≤ 7 jours entre
+  la publication Mozilla et le déploiement parc.

--- a/docs/manual/src/user/browser-hardening.md
+++ b/docs/manual/src/user/browser-hardening.md
@@ -1,0 +1,513 @@
+<!--
+SPDX-FileCopyrightText: 2026 Aurélien Ambert <aurelien.ambert@proton.me>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Durcissement du navigateur Sécurix
+
+Cette page documente le durcissement appliqué par Sécurix au-dessus
+de la baseline `firefox-esr` (voir `browser-baseline.md`). Elle
+couvre :
+
+- le modèle de menace pour un poste d'administration,
+- l'analyse détaillée de la surface WebRTC et des CVE associées,
+- la stratégie de mitigation en trois couches,
+- la configuration effectivement appliquée dans
+  `modules/tools/firefox.nix`,
+- une matrice de couverture sécuritaire zone par zone,
+- les implications concrètes pour l'administrateur utilisateur
+  du poste et pour le RSSI de l'entité déployante.
+
+---
+
+## 1. Modèle de menace
+
+Un poste Sécurix est utilisé par un administrateur de SI gouvernemental
+pour opérer de l'infrastructure sensible. Les caractéristiques qui
+guident le durcissement :
+
+- **Surface réseau variable** : le poste voyage (déplacements
+  inter-sites, salons, déplacements à l'étranger). Il passe par des
+  réseaux Wi-Fi non maîtrisés.
+- **Authentification forte** : FIDO2 / U2F est le facteur primaire
+  (cf. `modules/pam/u2f.nix`). Le navigateur n'est pas l'outil
+  d'authentification principal, mais il peut y participer via
+  WebAuthn pour des portails gouvernementaux.
+- **Visio nécessaire** : Jitsi, BigBlueButton, parfois Teams-web
+  pour les échanges inter-ministériels. La visio passe par
+  WebRTC — désactiver WebRTC casserait l'usage opérationnel.
+- **Pas de streaming grand public** : pas de YouTube, pas de
+  Netflix. EME (Widevine) est désactivé.
+- **Confidentialité des IPs internes** : le poste ne doit pas
+  laisser fuiter ses adresses IP de LAN / VPN vers des sites tiers.
+- **Traçabilité** : le RSSI doit pouvoir auditer le flux DNS et
+  le flux réseau sortant du navigateur, a minima sur le parc fixe.
+
+Le modèle d'attaquant considéré :
+
+- **Tracker / adtech** — volonté d'identifier l'utilisateur
+  (fingerprinting, IP leak) pour monétisation.
+- **Acteur opportuniste** — volonté d'exploiter une CVE
+  navigateur ou un composant (WebRTC codec, JS engine) pour
+  obtenir code-exec sur le poste.
+- **Acteur étatique ciblé** — volonté de pivoter depuis une
+  compromission initiale (phishing, watering hole) vers un canal
+  C2 persistant, en bypassant les mécanismes d'audit (DNS, proxy).
+
+Les défenses dites "privacy by default" (pas de télémétrie, pas
+d'accounts) sont déjà en place dans le bloc `policies` historique
+de Sécurix. Ce durcissement-ci ajoute les couches manquantes sur
+la surface réseau active du navigateur.
+
+---
+
+## 2. Surface d'attaque WebRTC
+
+WebRTC ne se résume pas à "RTCPeerConnection pour faire de la
+visio". C'est une stack complète qui expose **quatre surfaces
+distinctes**, chacune avec son vecteur.
+
+### 2.1 Fuite d'IP via ICE / STUN (privacy leak)
+
+L'API `RTCPeerConnection` oblige le navigateur à collecter des
+**ICE candidates** (toutes les adresses par lesquelles il pourrait
+être joint) avant même qu'un appel ne démarre :
+
+- `host` candidates → IP locales (`192.168.x.x`, `10.x.x.x`, IPv6
+  globale, VPN interne).
+- `srflx` candidates → IP publique vue par un serveur STUN (contacté
+  en UDP).
+- `relay` candidates → via TURN.
+
+**Problème** : une page peut créer une `RTCPeerConnection` **sans
+prompt utilisateur** — pas de permission requise pour simplement
+collecter les candidates (la permission caméra / micro n'arrive
+qu'après, lors du `getUserMedia`). Un tracker peut donc récupérer
+les IPs locales et publiques silencieusement.
+
+Depuis Firefox 70, les host candidates sont obfusquées en mDNS
+(UUID aléatoire), **mais uniquement côté API JS** — la résolution
+mDNS expose toujours l'existence de la machine sur le LAN. Et
+`srflx` reste en clair si STUN est joignable.
+
+**Impact Sécurix** : un admin sur réseau gouvernemental voit fuir
+son IP interne (10.x.y.z, routable VPN) vers n'importe quel site
+visité qui veut juste savoir.
+
+### 2.2 Exploit de la stack média (sandbox escape)
+
+WebRTC inclut :
+
+- **Codecs audio** : Opus, G.711.
+- **Codecs vidéo** : VP8, VP9, AV1, H.264 (via libavcodec ou
+  OpenH264).
+- **Parsing RTP / SRTP / DTLS**.
+- **Traitement SDP** (offer / answer).
+
+C'est **des milliers de lignes de C++ qui parsent des paquets
+réseau non-authentifiés**. Historiquement c'est la surface la plus
+riche en bugs mémoire du navigateur :
+
+| CVE | Date | Composant | Impact |
+|---|---|---|---|
+| CVE-2023-4863 | 2023-09 | libwebp (heap overflow) | RCE exploité in-the-wild (Pegasus, Chrome 0-day). Firefox impacté via rendu d'images. |
+| CVE-2024-9680 | 2024-10 | Animation timeline UAF | RCE exploité in-the-wild. Firefox ESR patch d'urgence. Chaînable WebRTC. |
+| CVE-2022-26485 | 2022-03 | XSLT (pas WebRTC direct) | Exploité en production contre journalistes. |
+| CVE-2019-11708 | 2019-06 | IPC sandbox escape | Chaîné avec RCE content-process (WebRTC le premier cran). |
+| CVE-2018-18500 | 2018-10 | SDP parser | Crash + potentiel RCE. |
+
+**Point clé** : le WebRTC stack est dans le **content process**.
+Un RCE WebRTC → attaquant dans le sandbox content. Pour s'évader,
+il faut un second bug (sandbox escape). Si
+`kernel.unprivileged_userns_clone = 0`, le sandbox content-process
+ne peut même pas démarrer correctement sur Firefox (fallback
+chroot-only ou non-sandboxé) : l'arbitrage sera tranché dans la
+Wave Q2 Sécurix.
+
+### 2.3 Fingerprinting device-level
+
+Même sans permission caméra / micro,
+`navigator.mediaDevices.enumerateDevices()` retourne :
+
+- Liste des caméras / micros avec label anonymisé (sauf si
+  permission déjà donnée — alors label = "USB Camera 2.0").
+- **`deviceId` stable par profil** → fingerprint persistant
+  cross-session sur le même site.
+- Nombre de devices → fingerprint machine.
+
+Combiné avec codec support + RTT STUN + timezone → identification
+quasi-unique.
+
+### 2.4 Tunnel C2 post-exploit
+
+Post-compromission, WebRTC est un vecteur d'exfiltration de choix :
+
+- UDP direct avec NAT hole-punching → bypass proxy HTTPS système.
+- DTLS encapsule n'importe quel payload.
+- Pas de SNI observable par middlebox.
+- TURN-over-TCP-443 ressemble à du TLS normal.
+
+Un malware qui a code-exec dans le content process (ou en escape)
+peut ouvrir un tunnel C2 via STUN / TURN publics sans toucher aux
+DNS loggés.
+
+---
+
+## 3. Stratégie de mitigation en trois couches
+
+Il n'existe **pas** de pref Firefox qui dirait "WebRTC API activée
+pour `meet.jit.si` uniquement". L'API est globale. On doit composer
+trois couches.
+
+### 3.1 Couche A — prefs globales pour réduire la surface IP-leak
+
+Configurée dans `policies.json / Preferences`, toutes en
+`Status = "locked"` :
+
+| Pref | Valeur | Effet |
+|---|---|---|
+| `media.peerconnection.enabled` | `true` | API reste disponible (sinon visio KO). |
+| `media.peerconnection.ice.no_host` | `true` | **Zéro host candidate** → pas de fuite IP LAN / VPN. |
+| `media.peerconnection.ice.default_address_only` | `true` | Une seule interface sortante → pas d'énumération multi-NIC. |
+| `media.peerconnection.ice.proxy_only_if_behind_proxy` | `true` | Force TURN si proxy système configuré. |
+| `media.peerconnection.identity.enabled` | `false` | Feature morte, surface code inutile. |
+| `media.navigator.enabled` | `true` | `enumerateDevices` nécessaire pour Jitsi. |
+| `media.peerconnection.turn.disable` | `false` | TURN nécessaire pour NAT symétrique en mobilité. |
+
+**Résultat** : WebRTC fonctionne (Jitsi, BBB, Teams-web marchent),
+mais sans leak d'IPs LAN / VPN et avec une seule interface srflx
+au lieu de l'énumération complète.
+
+### 3.2 Couche B — prompt caméra / micro par session
+
+Trois états possibles par origine pour caméra / micro :
+
+- `0 = ask` → prompt à l'utilisateur à chaque requête.
+- `1 = allow` → auto-grant sans prompt.
+- `2 = block` → auto-deny sans prompt.
+
+Sécurix force l'état `ask` pour caméra / micro / partage d'écran,
+et bloque dur la géolocalisation. En plus, `persistDecisions=false`
+empêche "Se souvenir de cette décision" — la permission retombe à
+`ask` à la fermeture de l'onglet.
+
+| Pref | Valeur | Effet |
+|---|---|---|
+| `permissions.default.camera` | `0` (ask) | Prompt natif à chaque requête caméra. |
+| `permissions.default.microphone` | `0` (ask) | Idem micro. |
+| `permissions.default.screen` | `0` (ask) | Idem partage d'écran. |
+| `permissions.default.geo` | `2` (block) | Géolocalisation bloquée dur — pas de prompt. |
+| `privacy.permissionPrompts.persistDecisions` | `false` | Pas de persistance — permission tombe à la fermeture. |
+
+Côté `Permissions` (verrouillage UI dans `about:preferences`) :
+
+| Entrée | Option | Effet |
+|---|---|---|
+| `Camera` | `Locked = true` | User ne peut pas désactiver la demande depuis `about:preferences`. |
+| `Microphone` | `Locked = true` | Idem. |
+| `Location` | `BlockNewRequests = true`, `Locked = true` | Pas de prompt, auto-deny. |
+| `Notifications` | `BlockNewRequests = true`, `Locked = true` | Pas de prompt notification. |
+| `Autoplay` | `Default = "block-audio-video"`, `Locked = true` | Aucun autoplay. |
+
+**Flux pour l'admin qui ouvre Jitsi** :
+
+1. Jitsi appelle `getUserMedia({video, audio})`.
+2. Firefox affiche la barre jaune : *"meet.jit.si demande à utiliser
+   votre caméra et micro"*.
+3. L'admin clique **[Autoriser]** → permission pour la session
+   courante.
+4. L'admin ferme l'onglet → permission retombe à `ask`.
+5. Prochaine visite → nouveau prompt.
+
+**Flux pour un site inattendu qui tente `getUserMedia`** :
+
+1. Prompt s'affiche.
+2. L'admin voit une demande suspecte → **[Bloquer]** ou **[×]**.
+3. Le site ne peut pas capturer.
+
+### 3.3 Couche C — layers réseau complémentaires
+
+Ces mesures ne sont **pas** configurables via `policies.json` et
+doivent être traitées hors scope du module Sécurix firefox — mais
+elles sont listées ici parce qu'elles **sont nécessaires** pour
+fermer les trous de la Couche A :
+
+| Risque résiduel Couche A | Layer à ajouter |
+|---|---|
+| Srflx IP publique observable au STUN | Allowlist firewall UDP 3478 / 5349 + DNS allowlist des domaines STUN / TURN approuvés. |
+| Tunnel C2 via TURN post-exploit | Même allowlist que ci-dessus — combinée avec détection SIEM sur UDP long-lived hors allowlist. |
+| Bypass du proxy HTTP en mobilité | VPN always-on tunnelisant l'UDP + force TURN-over-TCP-443 pour auditer. |
+
+---
+
+## 4. Autres durcissements appliqués par policies.json
+
+En dehors de WebRTC, plusieurs autres surfaces sont fermées :
+
+### 4.1 DoH (TRR) désactivé
+
+`network.trr.mode = 5` → DoH complètement désactivé. Raison : un
+DoH activé par Firefox **bypasse le résolveur DNS entreprise** et
+envoie les requêtes directement à un provider externe (Cloudflare
+par défaut dans certaines régions). Dans un contexte gouvernemental
+avec DNS interne logué, c'est une fuite et une perte de visibilité
+SIEM.
+
+### 4.2 PPA (Privacy-Preserving Attribution)
+
+`dom.private-attribution.submission.enabled = false`. Cette feature
+a été activée par défaut dans Firefox 128 (juillet 2024), sans
+consentement explicite, ce qui a déclenché une polémique notable.
+Elle envoie des informations d'attribution publicitaire agrégées à
+un serveur Mozilla. Désactivée pour toute installation Sécurix.
+
+### 4.3 Safe Browsing désactivé
+
+Les quatre prefs `browser.safebrowsing.{malware,phishing,downloads,
+downloads.remote}.enabled = false`. Safe Browsing pingue en continu
+`shavar.services.mozilla.com` qui proxyfie les listes Google Safe
+Browsing. Le tradeoff :
+
+- **Côté gain privacy** : pas de métadonnées de navigation
+  envoyées à Mozilla / Google.
+- **Côté perte** : plus d'alerte Firefox sur site de phishing /
+  malware connu.
+
+Compensation partielle : uBlock Origin pré-installé filtre la
+majorité des domaines malveillants connus via les listes
+EasyPrivacy / NoCoin / etc.
+
+### 4.4 Géolocalisation désactivée
+
+`geo.enabled = false` + `geo.provider.use_geoclue = false` (Linux).
+Et `permissions.default.geo = 2` au niveau permissions. Pas d'appel
+aux Google Location Services — même si une application tente une
+requête, elle échoue sans prompt.
+
+### 4.5 Connexions spéculatives / DNS prefetch
+
+Quatre prefs désactivées (`network.prefetch-next`,
+`network.dns.disablePrefetch`, `network.predictor.enabled`,
+`network.http.speculative-parallel-limit=0`). Chaque fois que la
+souris survole un lien, Firefox peut pré-résoudre le DNS et
+pré-ouvrir une connexion TCP / TLS. C'est une fuite passive de
+comportement vers les domaines non-cliqués.
+
+### 4.6 Suggestions de recherche
+
+`browser.search.suggest.enabled = false` et
+`browser.urlbar.suggest.searches = false`. Sans ça, chaque frappe
+dans la barre d'URL envoie une requête AJAX au moteur de recherche
+par défaut, révélant la frappe en temps réel (y compris les
+commandes partielles que l'utilisateur n'envoie jamais réellement).
+
+### 4.7 Debug distant désactivé
+
+`devtools.debugger.remote-enabled = false`. Les devtools locales
+restent utilisables (F12) — seule l'écoute TCP du debugger à
+distance est fermée, ce qui élimine un vecteur post-exploit pour
+piloter le navigateur depuis l'extérieur.
+
+### 4.8 Moteur de recherche par défaut
+
+`SearchEngines.Default = "Qwant"` + `SearchEngines.Add` pour
+ajouter explicitement l'entrée Qwant au profil. Non verrouillé
+(pas de `Locked = true`) : l'utilisateur peut basculer sur
+DuckDuckGo, Google, Startpage, etc. selon ses besoins
+opérationnels.
+
+Le choix Qwant apporte :
+
+- **Souveraineté numérique** : moteur français, infrastructure en
+  UE, pas de soumission au CLOUD Act américain.
+- **Politique no-tracking déclarée** : pas de profilage
+  publicitaire, pas de log IP utilisateur permanent.
+- **Cohérent avec le contexte gouvernemental** : aligné avec les
+  recommandations DINUM sur les services numériques d'État.
+- **Fallback intégré** : l'entrée `SearchEngines.Add` garantit la
+  présence de Qwant même si le pack de langue FR n'est pas actif
+  (edge case : poste en locale `en-US`). Sans cette précaution,
+  un `Default = "Qwant"` sur un profil non-FR fait silencieusement
+  retomber Firefox sur Google.
+
+Pour un déploiement qui préfère explicitement un autre moteur
+(DuckDuckGo pour recherches en anglais sur de la doc technique,
+Startpage pour un proxy Google neutre, etc.), surcharger
+`SearchEngines.Default` dans une couche locale au-dessus de ce
+module suffit. Le binding `qw` (alias déclaré pour Qwant) est
+accessible depuis la barre d'URL : `qw <requête>` cherche sur
+Qwant indépendamment du moteur par défaut.
+
+### 4.9 New Tab — pas de contenu sponsorisé
+
+`browser.newtabpage.activity-stream.showSponsored = false` et
+`showSponsoredTopSites = false`. La page de nouvel onglet, qui
+redirige vers le dashboard local Sécurix, n'affiche plus les
+"top sites sponsorisés" Mozilla.
+
+### 4.10 Capture formulaire désactivée
+
+`signon.formlessCapture.enabled = false`. Complément de
+`PasswordManagerEnabled=false` — empêche la capture passive de
+valeurs saisies dans des formulaires qui ne sont pas explicitement
+`<form>`. Utile contre les exfiltrations d'identifiants coincés
+dans des widgets JS non-standard.
+
+### 4.11 Fingerprinting resistance (opt-in)
+
+Activé seulement si `securix.firefox.hardenFingerprinting = true`.
+Deux prefs :
+
+- `privacy.resistFingerprinting = true`
+- `privacy.resistFingerprinting.letterboxing = true`
+
+Normalise timezone (toujours UTC), écran (letterboxing pour
+masquer la taille réelle), canvas, audio, liste de polices.
+Puissant mais **casse** de nombreux sites gouvernementaux
+(portails qui vérifient la cohérence timezone-locale, anti-fraude
+bancaire), d'où l'opt-in par déploiement.
+
+---
+
+## 5. Matrice de couverture sécuritaire
+
+Statut de chaque zone d'attaque après application du durcissement.
+
+Légende : ✅ couverte / 🟡 partielle / ❌ non couverte par le
+navigateur (relève d'une autre couche).
+
+| # | Zone d'attaque | Statut | Mécanisme actif | Limitation / pourquoi | Implication admin | Implication RSSI |
+|---|---|---|---|---|---|---|
+| 1 | Fuite IP LAN / VPN via host candidates | ✅ | `ice.no_host=true` | Aucune. | Transparent. | Topo interne préservée. |
+| 2 | Fuite IP publique via srflx / STUN | 🟡 | `default_address_only=true` — 1 interface sortante | L'IP publique reste visible au STUN contacté (nécessaire au fonctionnement ICE). | En mobilité, IP sortante observable par STUN du site. | Firewall allowlist STUN / TURN obligatoire. |
+| 3 | Capture caméra / micro drive-by | ✅ | Prompt natif + `persistDecisions=false` + `Locked=true` | Social engineering reste possible. | Refuser les prompts inattendus. | Formation "prompt suspect = bloquer". |
+| 4 | Fingerprinting `enumerateDevices` | 🟡 | Labels vides sans permission | `deviceId` stable par profil reste un fingerprint. | Transparent. | Accepté résiduel. Mitigation : profil unique par poste. |
+| 5 | Exploit codec RCE (WebRTC stack) | ❌ | — | Dépend du patch management. | Appliquer MAJ ESR. | SLA ≤ 7 jours, veille CERT-FR. |
+| 6 | Sandbox escape content-process | 🟡 | Sandbox Firefox natif (userns + seccomp + CGroups) | Dégradé si `unprivileged_userns=0` (Wave Q2). | Transparent. | Arbitrage Wave Q2. |
+| 7 | Tunnel C2 post-exploit via WebRTC | ❌ | — | JS peut ouvrir `RTCPeerConnection` silencieuse vers TURN public. | Invisible. | SIEM sur UDP 3478 / 5349 hors allowlist. |
+| 8 | NAT hole-punching hors proxy | 🟡 | `proxy_only_if_behind_proxy=true` | Sans proxy système, WebRTC sort direct UDP. | En mobilité, perd l'audit proxy. | VPN always-on + TURN-over-TCP. |
+| 9 | Codec fingerprinting via SDP | ❌ | — | SDP expose codecs supportés. | Transparent. | Accepté résiduel. Mitigation : parc homogène. |
+| 10 | Création silencieuse `RTCPeerConnection` | ❌ | — | API reste appelable. | Transparent. | Firewall DNS allowlist STUN / TURN. |
+| 11 | Peer Identity WebRTC (legacy) | ✅ | `identity.enabled=false` | Aucune. | Transparent. | Validé. |
+| 12 | Push de config remote (Normandy, Shield) | ✅ | `DisableFirefoxStudies`, `DisableTelemetry` | Aucune si policies à jour. | Transparent. | Validé. |
+| 13 | Partage d'écran `getDisplayMedia` | ✅ | `permissions.default.screen=0` + `Locked=true` | Social engineering "partagez votre écran". | Prompt à chaque partage. | Cf. formation (ligne 3). |
+| 14 | Géolocalisation (API + IP) | ✅ | `geo.enabled=false`, `permissions.default.geo=2` | IP reste observable réseau. | Transparent. | Validé côté JS API. |
+| 15 | Debug distant navigateur | ✅ | `devtools.debugger.remote-enabled=false` | Devtools locales restent accessibles. | Transparent. | Validé. |
+| 16 | Résolution DNS via DoH | ✅ | `network.trr.mode=5` | DNS système utilisé → loggué par DNS entreprise. | Transparent. | Permet filtrage et corrélation SIEM. |
+| 17 | PPA (Private Attribution) envoi télémétrie | ✅ | `dom.private-attribution.submission.enabled=false` | Aucune. | Transparent. | Validé depuis FF 128. |
+| 18 | Safe Browsing — ping Mozilla / Google | ✅ | 4 prefs `browser.safebrowsing.*.enabled=false` | Plus d'alerte phishing / malware Firefox. | Transparent. | Compensation partielle via uBlock Origin. |
+| 19 | Autoplay audio / vidéo | ✅ | `Permissions.Autoplay.Default="block-audio-video"` + `media.autoplay.default=5` | Aucune. | Transparent. | Validé. |
+| 20 | Connexions spéculatives / DNS prefetch | ✅ | 4 prefs réseau à `false / 0` | Aucune. | Transparent. | Réduit fuite DNS passive. |
+| 21 | Suggestions de recherche live | ✅ | `browser.search.suggest.enabled=false` | User tape, aucune requête avant [Entrée]. | Suggestions ne s'affichent plus. | Aucune requête par frappe → pas de leak moteur. |
+| 22 | Fingerprinting canvas / timezone / écran | 🟡 (opt-in) | `privacy.resistFingerprinting` si `securix.firefox.hardenFingerprinting=true` | Casse certains sites (intranet gov). | Dépend opt-in. | Arbitrage entité : activer pour populations sensibles. |
+| 23 | Capture formulaires non-`<form>` | ✅ | `signon.formlessCapture.enabled=false` + `PasswordManagerEnabled=false` | Aucune. | Transparent. | Validé. |
+| 24 | Contenu sponsorisé New Tab | ✅ | 2 prefs `showSponsored=false` | Aucune. | New Tab propre. | Validé. |
+
+---
+
+## 6. Ce que la matrice implique opérationnellement
+
+### 6.1 Pour l'administrateur (utilisateur du poste)
+
+1. **2 clics par session visio** : prompt caméra + prompt micro
+   à chaque ouverture Jitsi / BBB. Irritation minime mais
+   **garantit la conscience de la capture média**.
+2. **Réflexe "prompt inattendu = refuser"** : si un site non-visé
+   demande caméra / micro / partage d'écran, refuser
+   systématiquement. Cas typiques : onglet resté ouvert, redirect
+   via bannière pub compromise, tab-napping.
+3. **Mobilité = vigilance +** : en déplacement (airport, hôtel),
+   l'IP publique sortante fuit aux STUN (ligne 2 de la matrice).
+   Éviter de visiter des sites sensibles et de faire une visio en
+   parallèle.
+4. **Pas de "Se souvenir de cette décision"** : la permission
+   tombe à chaque fermeture d'onglet. Ne pas s'étonner du
+   re-prompt.
+5. **Suggestions de recherche absentes** : la barre d'URL ne
+   propose plus rien en live — il faut taper l'URL complète ou
+   appuyer sur [Entrée] pour chercher.
+6. **Safe Browsing inactif** : pas d'avertissement Firefox sur
+   site frauduleux — s'appuyer sur uBlock Origin et le bon sens
+   pour la détection.
+
+### 6.2 Pour le RSSI de l'entité
+
+**Ce que la config browser vous donne** — posture baseline ESR +
+hardening :
+
+1. Aucun auto-grant caméra / micro / partage d'écran possible.
+2. Aucune fuite IP interne (LAN / VPN) via STUN.
+3. Aucun push de config remote Mozilla (Normandy / Shield).
+4. Aucune requête DoH — DNS enterprise reste l'autorité.
+5. Aucune télémétrie PPA.
+6. Aucun ping Safe Browsing (pas de signal vers Mozilla / Google).
+7. Toutes les permissions média verrouillées — l'utilisateur ne
+   peut pas se bypass lui-même.
+
+**Ce que la config browser NE vous donne PAS**, à traiter ailleurs :
+
+| Risque résiduel | Layer de défense à ajouter | Priorité |
+|---|---|---|
+| Exploit codec WebRTC (0-day + N-day) | Patch mgmt ESR 140, SLA ≤ 7 j, abo Mozilla advisories, dashboard CVE | 🔴 Critique |
+| Tunnel C2 via TURN public | Firewall allowlist UDP 3478 / 5349 + DNS allowlist domaines STUN / TURN légitimes | 🔴 Critique |
+| Sandbox faible si `unprivileged_userns=0` | Décision Wave Q2 + compensation Tetragon DNS (PR #146) + isolation réseau | 🟠 Majeur |
+| Mobilité sans proxy | VPN always-on tunnels UDP + TURN-over-TCP pour audit | 🟠 Majeur |
+| Fingerprinting résiduel (deviceId, SDP codecs) | Profil utilisateur unique par poste ; homogénéité parc | 🟢 Résiduel accepté |
+| Social engineering prompt | Formation 10 min + piqûre rappel annuelle | 🟡 Organisationnel |
+
+**Ce que le RSSI doit documenter dans sa DSP / PAS** :
+
+- Adoption de la posture Sécurix browser (baseline ESR +
+  hardening) comme référence technique.
+- Règles firewall complémentaires (allowlist STUN / TURN).
+- SLA patch ESR.
+- Plan de formation utilisateurs.
+- Acceptation explicite des risques résiduels catégorie ❌.
+
+**Ce que le RSSI doit vérifier périodiquement** :
+
+- Versions `firefox-esr` déployées (pas de dérive vers une ESR EOL).
+- Revue trimestrielle des règles firewall STUN / TURN.
+- Test de la chaîne "CVE Mozilla → bump nixpkgs → déploiement" (SLA).
+- Alerte SIEM sur pattern UDP STUN hors allowlist.
+- Audit des sites autorisés dans les `Permissions.Camera.Allow` et
+  `Microphone.Allow` (si une entité ajoute une allowlist locale
+  au-dessus du default Sécurix).
+
+---
+
+## 7. Extensions actives sur Sécurix
+
+Deux extensions sont pré-installées et verrouillées :
+
+| Extension | Rôle | Source |
+|---|---|---|
+| **uBlock Origin** (`uBlock0@raymondhill.net`) | Blocage de trackers, annonces, domaines malveillants connus. Compensation partielle de Safe Browsing. | addons.mozilla.org signé Mozilla |
+| **Bitwarden** (`{446900e4-71c2-419f-a6a7-df9c091e268b}`) | Gestionnaire de mots de passe externe (Firefox interne désactivé). | addons.mozilla.org signé Mozilla |
+
+Toutes les autres extensions sont en `installation_mode = blocked`
+(cf. `ExtensionSettings."*".installation_mode`). L'ajout d'une
+extension nouvelle passe par une proposition sur le repo Sécurix.
+
+---
+
+## 8. Références
+
+- ANSSI — *Recommandations pour le déploiement sécurisé du
+  navigateur Mozilla Firefox sous Windows* —
+  <https://www.ssi.gouv.fr/entreprise/guide/recommandations-pour-le-deploiement-securise-du-navigateur-mozilla-firefox-sous-windows/>
+- Mozilla Enterprise Policies —
+  <https://mozilla.github.io/policy-templates/>
+- Mozilla Security Advisories —
+  <https://www.mozilla.org/en-US/security/advisories/>
+- CERT-FR (bulletins Firefox) — <https://www.cert.ssi.gouv.fr/>
+- `policies.json` — spécification de la pref
+  `dom.private-attribution.submission.enabled` (Firefox 128+).
+- NIST SP 800-63B rev. 3 (2017), § 5.1.1.2.
+- OWASP Top 10 — A07 Identification and Authentication Failures.
+- Zhang, Monrose, Reiter — *The Security of Modern Password
+  Expiration*, ACM CCS 2010 (hors scope navigateur mais cité dans
+  la posture de sécurité Sécurix adjacent).
+- `browser-baseline.md` — page sœur qui couvre le choix ESR, la
+  stratégie d'épinglage et la baseline ANSSI.

--- a/modules/tools/default.nix
+++ b/modules/tools/default.nix
@@ -81,8 +81,9 @@
     glibcInfo
     man-pages
     man-pages-posix
-    # Browser
-    firefox
+    # Browser is installed via `programs.firefox` (pinned to firefox-esr
+    # in modules/tools/firefox.nix) — not via systemPackages, which would
+    # pull in the rolling release in parallel.
     qrencode
   ];
 }

--- a/modules/tools/firefox.nix
+++ b/modules/tools/firefox.nix
@@ -88,6 +88,12 @@ in
 
     programs.firefox = {
       enable = true;
+      # Pin to Firefox ESR (security-only update channel, Mozilla-supported).
+      # Rationale: admin workstation posture favours a predictable release
+      # cadence with security-only patches over the rolling branch's feature
+      # churn. Upstream ESR ships ~1 major/year with ~1 year overlap; see
+      # `docs/manual/src/user/browser-baseline.md` for the update policy.
+      package = pkgs.firefox-esr;
       languagePacks = [
         "fr"
         "en-US"

--- a/modules/tools/firefox.nix
+++ b/modules/tools/firefox.nix
@@ -10,7 +10,7 @@
   ...
 }:
 let
-  inherit (lib) listToAttrs mkOption;
+  inherit (lib) listToAttrs mkOption mkEnableOption;
   inherit (lib.types) attrsOf submodule str;
 
   cfg = config.securix.firefox;
@@ -21,6 +21,7 @@ let
         type = str;
         default = "";
         description = ''
+
           Name of the icon of the bookmark.
         '';
       };
@@ -28,6 +29,7 @@ let
       href = mkOption {
         type = str;
         description = ''
+
           URL of the website that the bookmark points to.
         '';
       };
@@ -36,6 +38,7 @@ let
         type = str;
         default = "";
         description = ''
+
           Description of the website that the bookmark points to.
         '';
       };
@@ -47,6 +50,7 @@ in
     type = attrsOf (attrsOf bookmarkType);
     default = { };
     example = ''
+
       {
         Productivity = {
           Github = {
@@ -64,9 +68,20 @@ in
       }
     '';
     description = ''
+
       Bookmarks to show to homepage and firefox bookmarks.
     '';
   };
+
+  # Active `privacy.resistFingerprinting` + letterboxing. Normalise
+  # plusieurs vecteurs de fingerprinting (timezone, taille d'écran,
+  # canvas, audio, liste de polices), mais CASSE certains sites —
+  # notamment ceux qui vérifient une cohérence entre la taille
+  # d'écran annoncée et la vraie, ou les portails intranet qui
+  # dépendent du timezone local. Opt-in par déploiement ; désactivé
+  # par défaut pour préserver la compatibilité avec les portails
+  # gouvernementaux. Voir `docs/manual/src/user/browser-hardening.md`.
+  options.securix.firefox.hardenFingerprinting = mkEnableOption "Firefox fingerprinting resistance (privacy.resistFingerprinting + letterboxing)";
 
   config = {
     # This spawns the dashboard on 127.0.0.1:8082.
@@ -175,6 +190,257 @@ in
           FirefoxLabs = false;
           # If people wants to get spammed by Firefox… They can.
           Locked = false;
+        };
+
+        # ───────────────────────────────────────────────────────────────
+        # Durcissement browser — voir `docs/manual/src/user/browser-hardening.md`
+        # pour l'analyse détaillée (surface WebRTC, CVE, matrice de couverture
+        # et implications admin / RSSI).
+        # ───────────────────────────────────────────────────────────────
+
+        # Permissions par défaut verrouillées côté policy.
+        # La caméra et le micro ne sont PAS auto-accordés (pas de liste
+        # Allow) : chaque site qui demande voit le prompt Firefox natif,
+        # l'utilisateur décide par session. `persistDecisions=false` ci-dessous
+        # empêche la persistance (« Se souvenir de cette décision »).
+        Permissions = {
+          Camera = {
+            Locked = true;
+          };
+          Microphone = {
+            Locked = true;
+          };
+          Location = {
+            BlockNewRequests = true;
+            Locked = true;
+          };
+          Notifications = {
+            BlockNewRequests = true;
+            Locked = true;
+          };
+          Autoplay = {
+            Default = "block-audio-video";
+            Locked = true;
+          };
+        };
+
+        # Moteur de recherche par défaut : Qwant (opéré en France,
+        # infrastructure UE, politique no-tracking déclarée, aligné
+        # avec le principe de souveraineté numérique gouvernementale).
+        # `Add` ajoute l'entrée Qwant explicitement, au cas où le pack
+        # de langue FR ne serait pas actif à l'install (edge case :
+        # système en locale en-US). Non verrouillé (pas de `Locked`) :
+        # l'utilisateur peut basculer sur DuckDuckGo, Google, Startpage
+        # selon ses besoins opérationnels. Voir browser-hardening.md §4.8.
+        SearchEngines = {
+          Default = "Qwant";
+          Add = [
+            {
+              Name = "Qwant";
+              URLTemplate = "https://www.qwant.com/?q={searchTerms}";
+              Method = "GET";
+              IconURL = "https://www.qwant.com/favicon.ico";
+              Alias = "qw";
+              Description = "Moteur de recherche souverain français (infrastructure UE, politique no-tracking).";
+            }
+          ];
+        };
+
+        # Préférences durcies via les clés about:config.
+        # Chaque valeur est `Status = "locked"` — l'utilisateur ne peut
+        # pas la réactiver via about:config. Chaque groupe renvoie au
+        # point correspondant de la matrice de couverture dans
+        # browser-hardening.md.
+        Preferences = {
+          # === WebRTC — Couche A (prefs globales) ===
+          # API activée : nécessaire pour les outils visio (Jitsi, BBB,
+          # Teams-web, …). Le durcissement restreint la surface, pas
+          # l'accès à la fonctionnalité.
+          "media.peerconnection.enabled" = {
+            Value = true;
+            Status = "locked";
+          };
+          # Pas de host candidate → zéro fuite IP LAN / VPN aux STUN.
+          "media.peerconnection.ice.no_host" = {
+            Value = true;
+            Status = "locked";
+          };
+          # Une seule interface sortante → pas d'énumération multi-NIC.
+          "media.peerconnection.ice.default_address_only" = {
+            Value = true;
+            Status = "locked";
+          };
+          # Force TURN si un proxy système est configuré (audit réseau).
+          "media.peerconnection.ice.proxy_only_if_behind_proxy" = {
+            Value = true;
+            Status = "locked";
+          };
+          # Peer identity : feature WebRTC legacy, surface code inutile.
+          "media.peerconnection.identity.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+          # enumerateDevices nécessaire pour négocier caméra / micro
+          # dans Jitsi — reste activé.
+          "media.navigator.enabled" = {
+            Value = true;
+            Status = "locked";
+          };
+          # TURN nécessaire pour NAT symétrique en mobilité.
+          "media.peerconnection.turn.disable" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === Permissions — Couche B (prompt systématique) ===
+          # 0 = ask ; 1 = allow silently ; 2 = block silently.
+          "permissions.default.camera" = {
+            Value = 0;
+            Status = "locked";
+          };
+          "permissions.default.microphone" = {
+            Value = 0;
+            Status = "locked";
+          };
+          "permissions.default.screen" = {
+            Value = 0;
+            Status = "locked";
+          };
+          "permissions.default.geo" = {
+            Value = 2;
+            Status = "locked";
+          };
+          # Pas de « Se souvenir de cette décision » : la permission
+          # retombe à `ask` à la fermeture de l'onglet.
+          "privacy.permissionPrompts.persistDecisions" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === DoH (TRR) désactivé — conserve le DNS entreprise ===
+          "network.trr.mode" = {
+            Value = 5;
+            Status = "locked";
+          };
+          "network.trr.uri" = {
+            Value = "";
+            Status = "locked";
+          };
+
+          # === PPA — Privacy-Preserving Attribution ===
+          # Activé par défaut depuis Firefox 128 (juillet 2024).
+          "dom.private-attribution.submission.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === Safe Browsing désactivé — pas de ping Mozilla / Google ===
+          "browser.safebrowsing.malware.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+          "browser.safebrowsing.phishing.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+          "browser.safebrowsing.downloads.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+          "browser.safebrowsing.downloads.remote.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === Autoplay — redondance avec Permissions.Autoplay (belt + braces) ===
+          "media.autoplay.default" = {
+            Value = 5;
+            Status = "locked";
+          };
+          "media.autoplay.blocking_policy" = {
+            Value = 2;
+            Status = "locked";
+          };
+
+          # === Géolocalisation — pas de requête Google Location Services ===
+          "geo.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+          "geo.provider.use_geoclue" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === Connexions spéculatives / DNS prefetch ===
+          # Élimine les fuites DNS passives et les handshakes
+          # pre-navigation vers les domaines survolés.
+          "network.prefetch-next" = {
+            Value = false;
+            Status = "locked";
+          };
+          "network.dns.disablePrefetch" = {
+            Value = true;
+            Status = "locked";
+          };
+          "network.predictor.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+          "network.http.speculative-parallel-limit" = {
+            Value = 0;
+            Status = "locked";
+          };
+
+          # === Suggestions de recherche (requête moteur à chaque frappe) ===
+          "browser.search.suggest.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+          "browser.urlbar.suggest.searches" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === Debug distant ===
+          # Le debugger local reste disponible (utile pour les admins) ;
+          # seul le remote debugging TCP est désactivé.
+          "devtools.debugger.remote-enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === New Tab — pas de contenu sponsorisé ===
+          "browser.newtabpage.activity-stream.showSponsored" = {
+            Value = false;
+            Status = "locked";
+          };
+          "browser.newtabpage.activity-stream.showSponsoredTopSites" = {
+            Value = false;
+            Status = "locked";
+          };
+
+          # === Capture automatique de formulaires (saisie mots de passe) ===
+          # PasswordManagerEnabled=false couvre le stockage ; cette pref
+          # ferme la collecte passive via formless capture.
+          "signon.formlessCapture.enabled" = {
+            Value = false;
+            Status = "locked";
+          };
+        }
+        // lib.optionalAttrs cfg.hardenFingerprinting {
+          # === Résistance au fingerprinting (opt-in) ===
+          # Casse des sites qui vérifient une cohérence timezone /
+          # taille d'écran / canvas. À n'activer que si le parc visé
+          # n'a pas besoin d'accéder à des portails sensibles à cela.
+          "privacy.resistFingerprinting" = {
+            Value = true;
+            Status = "locked";
+          };
+          "privacy.resistFingerprinting.letterboxing" = {
+            Value = true;
+            Status = "locked";
+          };
         };
       };
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Ce PR est empilé sur [#154](https://github.com/cloud-gouv/securix/pull/154)** (bascule vers Firefox ESR).
> Merger #154 en premier — la diff ci-dessous inclut temporairement les deux commits.
> Une fois #154 mergé, la diff de ce PR se réduit à ses propres changements (1 fichier Nix + 2 fichiers de doc).

Ce PR complète le durcissement du navigateur par défaut (Firefox ESR
140.9.1esr, voir PR précédent sur la baseline). Il ferme les lacunes
identifiées dans le body de la baseline : PPA, WebRTC IP-leak,
DoH bypass DNS, Safe Browsing, autoplay, géolocalisation, connexions
spéculatives, suggestions de recherche par frappe, et persistance
des permissions caméra / micro.

**Dépendance** : ce PR est empilé sur le PR baseline
(`feat/tools-firefox-esr-baseline`). Il doit être mergé après. La
diff contre main inclut temporairement les deux commits.

## Stratégie

Trois couches, détaillées dans le nouveau document
`docs/manual/src/user/browser-hardening.md` :

- **Couche A** — prefs globales WebRTC pour réduire la surface IP
  leak sans casser les outils visio (Jitsi, BBB, Teams-web).
- **Couche B** — prompt caméra / micro natif à chaque session, pas
  d'auto-grant par allowlist statique, pas de persistance via
  "Se souvenir de cette décision".
- **Couche C** — layers réseau complémentaires (firewall allowlist
  STUN / TURN, DNS enterprise, VPN nomade, SIEM sur UDP
  long-lived hors allowlist). Ces layers sont hors scope du
  module Nix mais documentés comme obligatoires pour le RSSI.

Aucune liste blanche statique de sites visio dans `policies.json` :
l'admin voit le prompt Firefox natif à chaque activation caméra /
micro. Rationnel : awareness utilisateur > ergonomie ; prompt
obligatoire = l'admin voit une tentative inattendue et peut la
refuser consciemment.

## Ce que le PR change

`modules/tools/firefox.nix` :

- Nouvelle option `securix.firefox.hardenFingerprinting`
  (`mkEnableOption`, default off). Opt-in parce que
  `privacy.resistFingerprinting` casse des portails intranet
  gouvernementaux sensibles à la cohérence timezone / taille
  d'écran.
- Nouveau bloc `Permissions` dans `policies` : Camera /
  Microphone lockées (pas d'allowlist auto-grant), Location et
  Notifications en `BlockNewRequests=true`, Autoplay en
  `block-audio-video`.
- Nouveau bloc `SearchEngines` : `Default = "Qwant"` + `Add`
  d'une entrée Qwant explicite (moteur souverain français,
  infrastructure UE, no-tracking). `Add` garantit la présence de
  l'entrée même si le pack de langue FR n'est pas actif (edge
  case : poste en locale `en-US`, sinon `Default = "Qwant"`
  retomberait silencieusement sur Google). Non verrouillé —
  l'utilisateur peut basculer sur DuckDuckGo, Google, Startpage
  selon ses besoins.
- Nouveau bloc `Preferences` dans `policies` : 33 préférences
  `about:config` verrouillées (`Status = "locked"`), regroupées
  par thème (WebRTC, permissions par défaut, DoH, PPA, Safe
  Browsing, autoplay, géolocalisation, spéculative / prefetch,
  suggestions de recherche, debug distant, New Tab
  sponsorisé, capture formulaire).
- Bloc opt-in `hardenFingerprinting` (via `lib.optionalAttrs`)
  ajoutant deux prefs `resistFingerprinting` quand activé.

Nouvelle page `docs/manual/src/user/browser-hardening.md` — étude
complète du durcissement :

1. Modèle de menace admin workstation Sécurix.
2. Surface WebRTC en 4 sous-sections (fuite IP ICE, exploit stack
   média, fingerprinting devices, tunnel C2 post-exploit).
3. Tableau des CVE historiques WebRTC / codec (CVE-2023-4863
   libwebp, CVE-2024-9680, etc.).
4. Stratégie 3 couches avec valeurs exactes par couche.
5. Rationale détaillé de chaque pref verrouillée (DoH, PPA,
   Safe Browsing, géolocalisation, spéculatives, suggestions,
   debug distant, moteur de recherche par défaut, New Tab, capture
   formulaire, fingerprinting opt-in).
6. **Matrice de couverture — 24 zones d'attaque** avec statut
   ✅ / 🟡 / ❌, mécanisme actif, limitation résiduelle,
   implication admin, implication RSSI.
7. Section "Implications admin" (6 points pratiques user-visible).
8. Section "Implications RSSI" (7 points config browser acquis +
   6 points risques résiduels à traiter hors browser + points DSP
   / PAS + vérifications périodiques).
9. Tableau des extensions pré-installées (uBlock Origin, Bitwarden).

Indexation `docs/manual/src/SUMMARY.md` : ajout entrée
*Browser hardening*.

## Validation

```console
$ nix-build -A tests.full -o result-harden
$ P=$(readlink -f result-harden/etc/firefox/policies/policies.json)
$ echo "Size: $(stat -c%s $P) octets"
Size: 5661 octets

$ grep -c '"Status": "locked"' $P
33

$ grep -cE 'peerconnection|media.navigator' $P
7

$ grep -A2 'dom.private-attribution.submission.enabled' $P
      "dom.private-attribution.submission.enabled": {
        "Status": "locked",
        "Value": false

$ grep -A2 'trr.mode' $P
      "network.trr.mode": {
        "Status": "locked",
        "Value": 5

$ grep -A3 '"Autoplay"' $P
      "Autoplay": {
        "Default": "block-audio-video",
        "Locked": true
      }

$ grep -A2 '"Camera"' $P
      "Camera": {
        "Locked": true
      }

$ grep -A1 '"Default": "Qwant"' $P
      "Default": "Qwant",

$ grep '"Name": "Qwant"' $P
          "Name": "Qwant",
```

Validation sémantique :

- 33 préférences `about:config` verrouillées (`Status="locked"`).
- 7 préférences WebRTC (les 6 `peerconnection.*` + `navigator.enabled`).
- PPA (`dom.private-attribution.submission.enabled`) = `false`.
- DoH / TRR (`network.trr.mode`) = `5` (disabled).
- Autoplay (policy + pref) = bloqué.
- Camera / Microphone / Location / Notifications présentes dans
  `Permissions` avec `Locked=true`.
- Moteur par défaut = `Qwant` (non verrouillé), avec entrée Qwant
  ajoutée explicitement via `SearchEngines.Add`.
- `tests.full` instantié sans erreur d'évaluation de policies.

## Matrice de couverture (extrait)

La matrice complète de `browser-hardening.md` couvre 24 zones
d'attaque. Résumé des statuts :

- **✅ Couvertes (14 zones)** : fuite IP LAN / VPN via host,
  capture caméra drive-by, Peer Identity, Normandy / Shield,
  partage d'écran, géolocalisation API, debug distant, DoH,
  PPA, Safe Browsing, autoplay, spéculatives, suggestions, capture
  formulaire.
- **🟡 Partielles (5 zones)** : srflx IP publique via STUN,
  fingerprinting `enumerateDevices`, sandbox si `userns=0`,
  hole-punching hors proxy, fingerprinting canvas (opt-in).
- **❌ Non couvertes navigateur (5 zones)** — nécessitent layers
  réseau / patch / formation : RCE codec WebRTC, tunnel C2 via
  TURN, création `RTCPeerConnection` silencieuse, codec
  fingerprinting SDP, fuite IP publique mobilité.

Les zones ❌ sont **explicitement** documentées comme relevant
du RSSI de l'entité (patch SLA, firewall STUN / TURN, VPN
always-on, SIEM UDP, formation).

## Limitations

- **Prompt utilisateur à chaque session caméra / micro** : 2 clics
  par visio. C'est volontaire — awareness user > ergonomie — mais
  une entité qui veut un auto-grant pour son outil visio interne
  peut ajouter `Permissions.Camera.Allow` dans une surcouche
  locale au-dessus de ce module (l'option `Locked=true` n'empêche
  pas un `Allow` explicite de l'opérateur ; elle empêche
  seulement l'utilisateur de désactiver via `about:preferences`).
- **Safe Browsing désactivé** supprime les alertes Firefox sur
  phishing / malware connus. uBlock Origin pré-installé couvre
  partiellement via ses listes publiques (EasyPrivacy, NoCoin,
  etc.) mais n'est pas un remplacement équivalent.
- **Moteur par défaut Qwant** : choix aligné sur la souveraineté
  numérique gouvernementale (infrastructure UE, pas de CLOUD Act,
  politique no-tracking déclarée). Un déploiement qui préfère
  DuckDuckGo (pour recherches en anglais sur doc technique) ou
  Startpage (proxy Google neutre) peut surcharger `SearchEngines.Default`
  dans une couche locale au-dessus de ce module. L'alias `qw`
  déclaré dans `SearchEngines.Add` reste accessible depuis la
  barre d'URL indépendamment du moteur par défaut.
- **`hardenFingerprinting` est opt-in** parce que
  `privacy.resistFingerprinting` casse des portails
  gouvernementaux (anti-fraude bancaire, intranets qui
  vérifient la cohérence timezone). Les populations les plus
  sensibles (journalistes gov, cellules investigation) peuvent
  l'activer localement.
- **Pas de certification CSPN** : voir `browser-baseline.md` — la
  posture est alignée sur le guide de déploiement ANSSI publié,
  pas certifiée formellement.

## Références

- ANSSI — *Recommandations pour le déploiement sécurisé du
  navigateur Mozilla Firefox sous Windows* —
  <https://www.ssi.gouv.fr/entreprise/guide/recommandations-pour-le-deploiement-securise-du-navigateur-mozilla-firefox-sous-windows/>
- Mozilla Enterprise Policies —
  <https://mozilla.github.io/policy-templates/>
- Mozilla Security Advisories —
  <https://www.mozilla.org/en-US/security/advisories/>
- CERT-FR (bulletins Firefox) — <https://www.cert.ssi.gouv.fr/>
- Polémique PPA Firefox 128 (juillet 2024) — *Private-Attribution
  submission enabled by default*.
- CVE-2023-4863 (libwebp), CVE-2024-9680 (Animation UAF exploité
  in-the-wild).

