### PR TITLE
config: Readme Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ de cette VM.
 
 ## Licence
 
-Sécurix est distribué sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.
+Sécurix est distribué sous licence [MIT](https://github.com/cloud-gouv/securix/blob/main/LICENSES/MIT.txt). Voir le dossier `LICENSE` pour plus de détails.


### PR DESCRIPTION
There was a typo—it said “file,” but the licenses are actually in a folder. 🙂