### PR TITLE
auditd: implement ANSSI NT28 v2.0 R73 system activity audit

### DIFF
--- a/modules/auditd.nix
+++ b/modules/auditd.nix
@@ -14,11 +14,19 @@ let
 in
 {
   options.securix.audit = {
-    enable = mkEnableOption "la journalisation des évenements à des fins d'audit";
+    enable = mkEnableOption "auditd-based kernel event logging";
 
     adminEmail = mkOption {
       type = types.str;
-      description = "Email à qui envoyer les alertes d'espace disque";
+      description = "Email address notified when the audit log partition runs low on space.";
+    };
+
+    extraRules = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Additional audit rules to append to the default ANSSI-aligned ruleset.
+      '';
     };
   };
 
@@ -38,18 +46,56 @@ in
     security.audit = {
       enable = true;
       rules = [
-        # TODO:
-        # track audit itself accesses
-        # track shm accesses
-        # track mount/unmount
-        # track usb keys accesses
-        # track kernel module loading
-        # track kexec operations
-        # track network cards changes
-        # track thunderbolt changes
-        # This tracks only all execve for now, which is not that bad.
-        "-a exit,always -F arch=b64 -S execve"
-      ];
+        # ANSSI NT28 v2.0 R73 — system activity audit.
+        # See https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
+        # Audit subsystem tamper detection.
+        "-w /etc/audit/ -p wa -k audit-config"
+        "-w /etc/libaudit.conf -p wa -k audit-config"
+        "-w /etc/audisp/ -p wa -k audit-config"
+        "-w /var/log/audit/ -p wa -k audit-logs"
+        # Process execution.
+        "-a always,exit -F arch=b64 -S execve -k exec"
+        "-a always,exit -F arch=b32 -S execve -k exec"
+        # Privilege escalation (setuid/setgid family).
+        "-a always,exit -F arch=b64 -S setuid -S setgid -S setreuid -S setregid -S setresuid -S setresgid -k privilege-escalation"
+        "-a always,exit -F arch=b32 -S setuid -S setgid -S setreuid -S setregid -S setresuid -S setresgid -k privilege-escalation"
+        # Mount/unmount operations.
+        "-a always,exit -F arch=b64 -S mount -S umount2 -k mount"
+        "-a always,exit -F arch=b32 -S mount -S umount -S umount2 -k mount"
+        # Kernel module load/unload + modprobe config.
+        "-a always,exit -F arch=b64 -S init_module -S finit_module -S delete_module -k kernel-module"
+        "-a always,exit -F arch=b32 -S init_module -S finit_module -S delete_module -k kernel-module"
+        "-w /etc/modprobe.conf -p wa -k modprobe"
+        "-w /etc/modprobe.d/ -p wa -k modprobe"
+        "-w /etc/modules-load.d/ -p wa -k modprobe"
+        # kexec (live kernel replacement).
+        "-a always,exit -F arch=b64 -S kexec_load -S kexec_file_load -k kexec"
+        # Shared memory IPC.
+        "-a always,exit -F arch=b64 -S shmget -S shmat -S shmdt -S shmctl -k shm"
+        "-a always,exit -F arch=b32 -S ipc -k shm"
+        # USB / removable devices (evil-maid vector).
+        "-w /sys/bus/usb/ -p wa -k usb-devices"
+        # Thunderbolt (DMA-capable bus).
+        "-w /sys/bus/thunderbolt/ -p wa -k thunderbolt"
+        # Network interface / configuration changes.
+        "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k hostname-change"
+        "-w /etc/hosts -p wa -k network-config"
+        "-w /etc/resolv.conf -p wa -k network-config"
+        "-w /etc/NetworkManager/ -p wa -k network-config"
+        "-w /etc/systemd/network/ -p wa -k network-config"
+        "-w /etc/nftables.conf -p wa -k firewall-config"
+        # PAM / authentication subsystem changes.
+        "-w /etc/pam.d/ -p wa -k pam-config"
+        "-w /etc/security/ -p wa -k pam-config"
+        "-w /etc/u2f-mappings -p wa -k u2f-config"
+        # sudo / escalation configuration.
+        "-w /etc/sudoers -p wa -k sudo-config"
+        "-w /etc/sudoers.d/ -p wa -k sudo-config"
+        # Time changes (forensic timeline integrity).
+        "-a always,exit -F arch=b64 -S adjtimex -S settimeofday -S clock_settime -k time-change"
+        "-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S clock_settime -S stime -k time-change"
+        "-w /etc/localtime -p wa -k time-change"
+      ] ++ cfg.extraRules;
     };
   };
 }


### PR DESCRIPTION
Bonjour,

Mon objectif n'est pas de générer de la charge de travail pour rien mais de pouvoir aider sur les sujets de sécurité. Je commence avec NixOS et GitHub Actions — il ne faut pas hésiter à me dire ce qui va ou ne va pas, je m'adapterai et améliorerai ma façon de faire. Je vais désormais traiter mes PR sur mon fork, puis les proposer ici une fois validées.

---

Replaces the single execve rule + TODO block in modules/auditd.nix
with a ruleset aligned on ANSSI NT28 v2.0 R73 ("Journaliser l'activité
système avec auditd") and extends it with Sécurix-specific entries the
guide does not cover (PAM, sudo, time).

R73 gives an example ruleset of roughly ten rules. The module shipped
here has 34 default rules grouped into 18 keys, plus an opt-in
`securix.audit.extraRules` list for site-specific additions. Framing
the delta honestly as "R73-aligned + Sécurix extensions" rather than
"R73-compliant".

## What

```nix
{
  securix.audit = {
    enable = true;                     # unchanged
    adminEmail = "secops@example.fr";  # unchanged, description translated to English

    # New opt-in extension point, default [ ]:
    extraRules = [
      # "-a always,exit -F arch=b64 -S foo -k my-key"
    ];
  };
}
```

Default ruleset — 34 rules, 18 keys:

```
audit-config            (watches on /etc/audit, /etc/libaudit.conf, /etc/audisp)
audit-logs              (watch on /var/log/audit)
exec                    (b64+b32 execve)
privilege-escalation    (setuid/setgid family, b64+b32)
mount                   (mount, umount, umount2, b64+b32)
kernel-module           (init_module, finit_module, delete_module, b64+b32)
modprobe                (watches on modprobe.conf, modprobe.d, modules-load.d)
kexec                   (kexec_load, kexec_file_load)
shm                     (shmget, shmat, shmdt, shmctl; b32 ipc)
usb-devices             (watch on /sys/bus/usb)
thunderbolt             (watch on /sys/bus/thunderbolt)
hostname-change         (sethostname, setdomainname)
network-config          (watches on /etc/hosts, /etc/resolv.conf,
                         /etc/NetworkManager, /etc/systemd/network)
firewall-config         (watch on /etc/nftables.conf)
pam-config              (watches on /etc/pam.d, /etc/security)
u2f-config              (watch on /etc/u2f-mappings)
sudo-config             (watches on /etc/sudoers, /etc/sudoers.d)
time-change             (adjtimex, settimeofday, clock_settime; watch on /etc/localtime)
```

The `extraRules` list is appended verbatim, enabling site-specific
tuning without forking the module.

## Validation

Build closure:

```
# nix-build -A tests.full -o result-full
/nix/store/z1xfvvnyg5ppgs5nczqv56nd7kwdrf33-nixos-system-securix-unbranded-FULL-001-25.11.1056.d9bc5c7dceb3
```

Runtime validation on a fresh Sécurix VM (25.11.9418): generated the
ruleset file from the module default list and loaded it directly into
the kernel audit subsystem:

```
# auditctl -e 1
# auditctl -R /tmp/test.rules
# auditctl -l | wc -l
34
```

Triggered representative events for each key and counted matching
`type=SYSCALL` records (CONFIG_CHANGE/add_rule noise excluded):

```
audit-config           4   (touch /etc/audit/zzz-test)
audit-logs             2   (touch /var/log/audit/zzz-test)
exec                 184   (ambient — every shell execve)
privilege-escalation 263   (ambient — SSH login, setpriv, sudo)
mount                  2   (mount --bind; umount)
kernel-module          2   (modprobe dummy; modprobe -r dummy)
modprobe               4   (touch /etc/modprobe.d/zzz-test)
shm                    2   (ipcmk -M 1024 && ipcrm -m <id>)
hostname-change        4   (hostname audit-test; hostname <orig>)
network-config         3   (writes to /etc/resolv.conf,
                             /etc/systemd/network)
firewall-config        2   (touch /etc/nftables.conf)
pam-config             4   (touch /etc/pam.d/zzz-audit-test)
u2f-config             2   (touch /etc/u2f-mappings)
sudo-config            3   (touch /etc/sudoers.d/zzz-audit-test)
time-change            2   (date -s "$(date)")
```

15 / 18 keys validated with live syscall events. The 3 remaining
(`kexec`, `usb-devices`, `thunderbolt`) cannot be safely triggered in
a plain x86_64 QEMU VM without hardware passthrough — their rules
are confirmed loaded via `auditctl -l` and will fire in production
when the underlying events occur.

Sample SYSCALL record (pam-config):

```
type=SYSCALL ... syscall=257 success=yes ... comm="touch"
   exe=".../coreutils" key="pam-config"
```

## Limitations

- Not a verbatim transcription of R73: ANSSI's example in NT28 v2.0
  §11.3 is roughly ten rules; this ships 34 with Sécurix-specific
  additions (PAM, sudo, time). Strict-compliance sites should check
  the guide.
- `auditctl` emits "Old style watch rules are slower" for each `-w`
  rule at load time. Keeping the `-w` form because R73's own example
  uses it; a later refactor to `-a always,exit -F path=...` could
  eliminate the warning.
- No `exclude` rules for legitimate-but-noisy syscalls issued by
  systemd on routine operations (package upgrades, service restarts).
  Quiet logs require operator-supplied excludes via `extraRules`.
- `kexec`, `usb-devices`, `thunderbolt` were not functionally
  triggered in the test VM (would require a kexec into a new kernel,
  a USB passthrough, or TB hardware respectively). Rules are loaded
  but coverage is inferred from the audit subsystem's documented
  behaviour, not observed.

## Refs

- ANSSI NT28 v2.0 — R73 "Journaliser l'activité système avec auditd"
  https://cyber.gouv.fr/publications/recommandations-de-securite-relatives-un-systeme-gnulinux
- Linux Audit upstream rule examples:
  https://github.com/linux-audit/audit-userspace/tree/master/rules
- CIS Distribution-Independent Linux Benchmark §4.1 (Audit)

<details>
<summary>Authoring note</summary>

Drafted with Claude (Anthropic) as a writing assistant. All Nix code, shell scripts and documentation in this PR were reviewed and built locally against the Sécurix `tests.full` closure before push. Every design choice is mine and attributed under my name. Disclosure added in response to the maintainer's explicit request on #134.

</details>
