### PR TITLE
fix: validate the verb passed to the upgrade command

### DIFF
--- a/modules/updates/permissionless-upgrade.nix
+++ b/modules/updates/permissionless-upgrade.nix
@@ -298,12 +298,35 @@ let
       done
 
       # Ensure an upgrade verb is provided
-      if [ -z "$1" ]; then
+      if [ -z "''${1:-}" ]; then
         echo "No upgrade verb provided. Available options:
         - switch: Activate the new system right now. Warning: this can break your session.
         - boot: Activate the new system on the next reboot.
         - test: Activate the new system now but doesn't add it to the bootloader. If anything goes wrong, a reboot will revert to the old version.
         - dry-activate: Perform a dry activation - builds the system and explains what the activation will cause in terms of systemd service restarts and other actions. Helps you decide whether to switch or boot."
+        exit 1
+      fi
+
+      # Validate the upgrade verb against the list of accepted values.
+      # Without this check, a wrong syntax such as `upgrade test my-branch` would
+      # be silently accepted (the extra positional argument was ignored and the
+      # upgrade proceeded on the default branch). See issue #56.
+      case "$1" in
+        switch|boot|test|dry-activate) ;;
+        *)
+          echo "Unknown upgrade verb: '$1'. Expected one of: switch, boot, test, dry-activate." >&2
+          echo "Run 'upgrade --help' for usage." >&2
+          exit 1
+          ;;
+      esac
+
+      # Reject any trailing positional argument: options such as --branch must
+      # be passed before the verb, so nothing should remain after it.
+      if [ "$#" -gt 1 ]; then
+        shift
+        echo "Unexpected extra argument(s) after verb: $*" >&2
+        echo "Options such as --branch must be passed before the verb." >&2
+        echo "Run 'upgrade --help' for usage." >&2
         exit 1
       fi
 


### PR DESCRIPTION
Closes #56.

### Problem

`upgrade` forwards `$1` to `nixos-rebuild` without validating it, and
silently ignores any trailing positional argument. So an invocation like

    sudo upgrade test fix/my-branch

is accepted: `test` is used as the verb, `fix/my-branch` is dropped, and
the rebuild runs on the default branch instead of the one the operator
wanted to test. Same thing with typos on the verb (e.g. `swtich`), which
just fall through to `nixos-rebuild` with an unhelpful error.

### Change

* Validate the verb against the documented list (`switch`, `boot`,
  `test`, `dry-activate`) and exit with a clear message otherwise.
* Reject any positional argument after the verb, and hint that options
  like `--branch` must come before the verb.
* Guard the "no verb provided" check with `${1:-}` so it keeps working
  under the `set -u` enabled by `writeShellApplication` (otherwise the
  current code errors out with `$1: unbound variable` before printing
  the intended message).

### How I tested

Built the module locally and ran the resulting `upgrade` binary against
the following cases, all behaving as expected:

| Command                                              | Expected                                            |
| ------------------------------------------ | ---------------------------------------- |
| `sudo upgrade`                                      | prints help, exit 1                                |
| `sudo upgrade wrong-verb`                  | "Unknown upgrade verb", exit 1         |
| `sudo upgrade test fix/my-branch`       | "Unexpected extra argument", exit 1  |
| `sudo upgrade --branch fix/x test`        | proceeds normally                              |
| `sudo upgrade switch` / `boot` / `test`  | proceeds normally                              |

No changes to the Nix API or to the existing NixOS tests.