### PR TITLE
Add flake support with formatting and EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+max_line_length = 80
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This commit introduces comprehensive flake support to the Sécurix repository:

Changes made:
- Added flake.nix with x86_64-linux target, including treefmt-nix integration for Nix code formatting with nixfmt
- Created flake.lock for dependency pinning (nixpkgs, treefmt-nix)
- Added .editorconfig with standard formatting rules (UTF-8, LF line endings, 2-space indentation, 80-char line length)
- Fixed string literal formatting in modules/self.nix to comply with nixfmt standards (converted multi-line strings to single-line strings where appropriate)

Testing:
- Verified flake structure with 'nix flake show'
- Ran 'nix flake check' successfully - all checks passed including formatting
- devShells configured with nixpkgs-fmt and statix for development

Breaking changes:
- None: flake support is additive and doesn't affect existing configurations

Note: This implementation was assisted by GitHub Copilot CLI, which provided guidance on flake structure, formatting standards, and troubleshooting during the integration process.