### PR TITLE
feat: add french dictionary in firefox

### DIFF
--- a/modules/tools/firefox.nix
+++ b/modules/tools/firefox.nix
@@ -155,6 +155,7 @@ in
           // (listToAttrs [
             (extension "ublock-origin" "uBlock0@raymondhill.net")
             (extension "bitwarden-password-manager" "{446900e4-71c2-419f-a6a7-df9c091e268b}")
+            (extension "dictionnaire_francais1" "fr-dicollecte@dictionaries.addons.mozilla.org")
           ]);
 
         DisablePocket = true;


### PR DESCRIPTION
Securix installs by default french language pack 

```json
    programs.firefox = {
      enable = true;
      languagePacks = [
        "fr"
        "en-US"
      ];
```

But it lacks french dictionary to let the user to be able to choose french language orthographic corrections.

This PR proposes to fix this by adding the official french dictionary extension.