### PR TITLE
fix(anssi): use string comparison in mkSysctlChecker

### DIFF
--- a/modules/anssi/kernel-options.nix
+++ b/modules/anssi/kernel-options.nix
@@ -6,11 +6,18 @@ let
   mkSysctlChecker =
     lib: attrs:
     let
+      # Normalize whitespace (tabs to spaces, collapse runs, trim edges)
+      # so that sysctl output like "32768\t65535" matches Nix value "32768 65535".
+      normalizeWhitespace = ''tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//' '';
       mkCheckSingularSysctl = attr: expectedValue: ''
         # Check for sysctl '${attr}'
-        actual_value=$(sysctl -n "${attr}")
-        if [[ "$actual_value" -ne "${toString expectedValue}" ]]; then
-          echo "Check failed for ${attr}: expected ${toString expectedValue}, got $actual_value"
+        actual_value=$(sysctl -n "${attr}" | ${normalizeWhitespace}) || {
+          echo "Check failed for ${attr}: unable to read sysctl value"
+          exit 1
+        }
+        expected_value=$(echo "${toString expectedValue}" | ${normalizeWhitespace})
+        if [[ "$actual_value" != "$expected_value" ]]; then
+          echo "Check failed for ${attr}: expected $expected_value, got $actual_value"
           exit 1
         else
           echo "Check passed for ${attr}"


### PR DESCRIPTION
## Context

Fixes #118

The `mkSysctlChecker` helper in `modules/anssi/kernel-options.nix` uses bash arithmetic comparison (`-ne`) to verify sysctl values. This crashes on multi-word values like `net.ipv4.ip_local_port_range` which returns `32768 65535`.

Additionally, the check was not fail-safe: if `sysctl -n` failed or the comparison expression was malformed, the script would continue as if the check passed.

## Changes

- Replace `-ne` (arithmetic) with `!=` (string comparison)
- Normalize whitespace before comparing (sysctl outputs tab-separated values, Nix uses spaces)
- Add explicit error handling when `sysctl -n` fails, so the check correctly reports a failure instead of silently passing

## Testing

This change only affects the compliance check scripts generated at build time. The sysctl configuration itself is unchanged.
