### PR TITLE
Add EditorConfig with standard formatting rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+max_line_length = 80
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This pull request adds a repository-wide EditorConfig configuration file that defines consistent formatting standards across the project.

## Changes

- Added .editorconfig with standard formatting rules:
  * UTF-8 charset encoding
  * LF (Unix) line endings
  * 2-space indentation for all files
  * 80-character maximum line length
  * Insert final newline at end of files
  * Trim trailing whitespace

## Purpose

These settings ensure consistent code style and formatting across different editors and development environments, improving collaboration and reducing formatting-related changes in version control.

## Testing

- Verified .editorconfig syntax and structure
- Confirmed compatibility with common editors

Note: This contribution was assisted by GitHub Copilot CLI.