### PR TITLE
fix: --do-not-pull not working in upgrade script

### DIFF
--- a/modules/updates/permissionless-upgrade.nix
+++ b/modules/updates/permissionless-upgrade.nix
@@ -253,6 +253,7 @@ let
 
       # Default values
       BRANCH="${config.securix.auto-updates.branch}"
+      REPO_PATH="${self.infraRepositoryPath}"
       SUBDIR="${self.infraRepositorySubdir}"
       REMOTE_PULL=true
       USE_SN=false

--- a/modules/updates/permissionless-upgrade.nix
+++ b/modules/updates/permissionless-upgrade.nix
@@ -338,8 +338,6 @@ let
       if [ "$REMOTE_PULL" = true ]; then
         git -C "${self.infraRepositoryPath}" fetch origin
         if [ "$BRANCH" == "${config.securix.auto-updates.branch}" ]; then
-          REPO_PATH="${self.infraRepositoryPath}"
-
           # Update the repo.
           # On main branch, it's ABSOLUTELY forbidden to do anything else than --ff-only.
           git -C "${self.infraRepositoryPath}" switch "${config.securix.auto-updates.branch}"


### PR DESCRIPTION
Fixes #34

### What changed?
- Added a default value for 'REPO_PATH' in modules/updates/permissionless-upgrade.nix

### Motivation
Solves issue where the '--do-not-pull' argument is passed, leading to an if block being avoided where the 'REPO_PATH' variable was defined, letting it be called without previous definition.