### PR TITLE
Idempotent autoinstall

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -315,6 +315,15 @@ rec {
 
                 umount -R /mnt || true
 
+        	for dm in /dev/mapper/*; do
+        	  [ "$dm" = "/dev/mapper/control" ] && continue
+        	  ${pkgs.cryptsetup}/bin/cryptsetup close "$dm" 2>/dev/null \
+        	    || ${pkgs.lvm2}/bin/dmsetup remove -f "$dm" 2>/dev/null \
+        	    || true
+        	done
+        	${pkgs.lvm2}/bin/vgchange -an 2>/dev/null || true
+        	${pkgs.systemd}/bin/udevadm settle
+
                 box_message "Welcome in the Securix automatic installer."
                 log_info "Here is the list of current block devices."
                 lsblk

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -6,4 +6,5 @@
 {
   minimal = import ./minimal.nix { inherit pkgs libSecurix; };
   anssi-minimal = import ./anssi-minimal.nix { inherit pkgs libSecurix; };
+  idempotent-autoinstall = import ./idempotent-autoinstall.nix { inherit pkgs libSecurix; };
 }

--- a/tests/idempotent-autoinstall.nix
+++ b/tests/idempotent-autoinstall.nix
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2026 Mattias Kockum <mattias@kockum.net>
+#
+# SPDX-License-Identifier: MIT
+#
+# Regression test for https://github.com/cloud-gouv/securix/issues/171
+#
+# Boots a Securix installer then runs `autoinstall-terminal` twice.
+# The second run must succeed, which only happens if dm-crypt
+# handles are properly closed before wiping the disk.
+
+{ pkgs, libSecurix }:
+
+let
+  lib = pkgs.lib;
+
+  targetSystem = pkgs.nixos (
+    { lib, ... }:
+    {
+      imports = [ "${pkgs.disko.src}/module.nix" ];
+
+      options.securix.self.mainDisk = lib.mkOption { type = lib.types.str; };
+
+      config = {
+        securix.self.mainDisk = "/dev/vdb";
+
+        disko.devices.disk.main = {
+          device = "/dev/vdb";
+          type = "disk";
+          content = {
+            type = "gpt";
+            partitions.root = {
+              size = "100%";
+              content = {
+                type = "luks";
+                name = "securix-root";
+                passwordFile = "/tmp/disk-passphrase";
+                content = {
+                  type = "filesystem";
+                  format = "ext4";
+                  mountpoint = "/";
+                };
+              };
+            };
+          };
+        };
+
+        users.users.root.initialPassword = "test";
+        fileSystems."/".device = "/dev/mapper/securix-root";
+        fileSystems."/".fsType = "ext4";
+        boot.loader.grub.enable = false;
+      };
+    }
+  );
+
+  installer = libSecurix.buildInstallerSystem {
+    inherit targetSystem;
+    installScript = "echo 'install skipped for test'";
+    preprovisionOptions = {
+      secureBoot = "disabled";
+      tpm2HostKeys = false;
+      ageHostKeys = false;
+    };
+  };
+
+  autoinstallPkg = lib.findFirst (
+    p: p.name or "" == "autoinstall-terminal"
+  ) (throw "autoinstall-terminal not found in installer packages") installer.config.environment.systemPackages;
+
+in
+pkgs.testers.nixosTest {
+  name = "autoinstall-terminal-idempotent";
+
+  nodes.machine =
+    { ... }:
+    {
+      virtualisation.emptyDiskImages = [ 4096 ];
+      environment.systemPackages = [
+        autoinstallPkg
+        pkgs.expect
+      ];
+    };
+
+  testScript = ''
+    import textwrap
+
+    run_autoinstall = textwrap.dedent("""\
+        expect <<'EXPECT_EOF'
+        set timeout 300
+        spawn autoinstall-terminal
+        expect "Proceed with reformatting?"
+        send "\r"
+        expect {
+            "Installation is complete" { exit 0 }
+            timeout { puts "TIMEOUT"; exit 1 }
+            eof { puts "UNEXPECTED EOF"; exit 1 }
+        }
+        EXPECT_EOF
+    """)
+
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("echo -n 'testpassphrase' > /tmp/disk-passphrase")
+
+    machine.succeed(run_autoinstall)
+    machine.succeed(run_autoinstall)
+  '';
+}


### PR DESCRIPTION
Fixes #171 

### What changed?
- Added test for installer idempotency
- Added a section in installer code that cleans pre-existings mappings before install

### Motivation
Solves issue where the installer fails to install on a previously mapped disk.