### PR TITLE
Sécurix for qemu / kvm

### DIFF
--- a/hardware/default.nix
+++ b/hardware/default.nix
@@ -11,5 +11,6 @@
     ./x9-15.nix
     ./e14-g7.nix
     ./x13-20ug.nix
+    ./qemu-vm.nix
   ];
 }

--- a/hardware/qemu-vm.nix
+++ b/hardware/qemu-vm.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 darkone@darkone.yt
+#
+# SPDX-License-Identifier: MIT
+
+# Configuration minimale pour VM QEMU/KVM
+
+{ lib, pkgs, ... }:
+{
+  # Kernel d'usage général, pas de durcissement spécifique au matériel
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  # Pilotes virtio pour disques et réseau
+  boot.initrd.kernelModules = [ "virtio" "virtio_pci" "virtio_blk" "virtio_net" ];
+
+  # Pas de microcode AMD/Intel nécessaire
+  hardware.cpu.amd.updateMicrocode = false;
+  hardware.cpu.intel.updateMicrocode = false;
+
+  # Pas de firmware supplémentaire pour VM
+  hardware.firmware = lib.mkForce [ ];
+
+  # Support de base pour l'interface graphique QEMU
+  services.xserver.videoDrivers = [ "virtio" "fbdev" ];
+
+  # Optimisations VM
+  services.qemuGuest.enable = true;
+
+  # Pas de TPM2 émulé par défaut (TODO)
+  security.tpm2.enable = lib.mkForce false;
+
+  # Pas d'agent SSH TPM pour la VM (TODO)
+  securix.ssh.tpm-agent.hostKeys = lib.mkForce false;
+  securix.ssh.tpm-agent.sshKeys = lib.mkForce false;
+}

--- a/hardware/qemu-vm.nix
+++ b/hardware/qemu-vm.nix
@@ -10,7 +10,12 @@
   boot.kernelPackages = pkgs.linuxPackages_latest;
 
   # Pilotes virtio pour disques et réseau
-  boot.initrd.kernelModules = [ "virtio" "virtio_pci" "virtio_blk" "virtio_net" ];
+  boot.initrd.kernelModules = [
+    "virtio"
+    "virtio_pci"
+    "virtio_blk"
+    "virtio_net"
+  ];
 
   # Pas de microcode AMD/Intel nécessaire
   hardware.cpu.amd.updateMicrocode = false;
@@ -20,7 +25,10 @@
   hardware.firmware = lib.mkForce [ ];
 
   # Support de base pour l'interface graphique QEMU
-  services.xserver.videoDrivers = [ "virtio" "fbdev" ];
+  services.xserver.videoDrivers = [
+    "virtio"
+    "fbdev"
+  ];
 
   # Optimisations VM
   services.qemuGuest.enable = true;

--- a/hardware/qemu-vm.nix
+++ b/hardware/qemu-vm.nix
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 darkone@darkone.yt
+#
+# SPDX-License-Identifier: MIT
+
+# Configuration minimale pour VM QEMU/KVM
+
+{ lib, pkgs, ... }:
+{
+  # Kernel d'usage général, pas de durcissement spécifique au matériel
+  boot.kernelPackages = pkgs.linuxPackages_latest;
+
+  # Pilotes virtio pour disques et réseau
+  boot.initrd.kernelModules = [
+    "virtio"
+    "virtio_pci"
+    "virtio_blk"
+    "virtio_net"
+  ];
+
+  # Pas de microcode AMD/Intel nécessaire
+  hardware.cpu.amd.updateMicrocode = false;
+  hardware.cpu.intel.updateMicrocode = false;
+
+  # Pas de firmware supplémentaire pour VM
+  hardware.firmware = lib.mkForce [ ];
+
+  # Support de base pour l'interface graphique QEMU
+  services.xserver.videoDrivers = [
+    "virtio"
+    "fbdev"
+  ];
+
+  # Optimisations VM
+  services.qemuGuest.enable = true;
+}

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -380,8 +380,8 @@ rec {
             {
               imports = [ "${modulesPath}/installer/cd-dvd/installation-cd-base.nix" ];
               # This is an intermediate priority override, normal override is 100, mkDefault is 1000. We take the middle here.
-              networking.hostName = lib.mkOverride 500 "m${toString targetSystem.config.securix.self.inventoryId}";
-              system.nixos.tags = [ "m${toString targetSystem.config.securix.self.inventoryId}" ];
+              networking.hostName = lib.mkOverride 500 "m${toString targetSystem.config.securix.self.machine.inventoryId}";
+              system.nixos.tags = [ "m${toString targetSystem.config.securix.self.machine.inventoryId}" ];
 
               isoImage.storeContents = [ targetSystemClosure ];
               isoImage.squashfsCompression = compression;
@@ -554,7 +554,7 @@ rec {
 
             Email: ${config.securix.self.user.email}
             Machine: ${config.securix.self.machine.hardwareSKU}
-            Numéro: ${toString config.securix.self.inventoryId}
+            Numéro: ${toString config.securix.self.machine.inventoryId}
           '';
         in
         pkgs.writeText "inventory.md" ''

--- a/modules/self.nix
+++ b/modules/self.nix
@@ -164,6 +164,7 @@ in
           "x9-15"
           "e14-g7"
           "x13-20ug"
+          "qemu-vm"
         ];
         description = "Identifiant de configuration du matériel";
         example = "x280";


### PR DESCRIPTION
Sécurix in a QEMU/KVM virtual machine, for testing.

- A minimal machine with no hardening at this time.
- Here is a [sample project](https://github.com/darkone-linux/securix-kvm).