### PR TITLE
npins/sources: nixpkgs goes to 26.05

### DIFF
--- a/modules/vpn/ipsec/firewall.nix
+++ b/modules/vpn/ipsec/firewall.nix
@@ -31,11 +31,11 @@ in
   config = mkIf cfg.enable {
     services.resolved = {
       enable = true;
-      dnssec = "false";
-      llmnr = "false";
-      extraConfig = ''
-        MulticastDNS=false
-      '';
+      settings.Resolve = {
+        DNSSEC = false;
+        LLMNR = false;
+        MulticastDNS = false;
+      };
     };
     networking.firewall.enable = false;
     networking.nftables = {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -60,9 +60,9 @@
     },
     "nixpkgs": {
       "type": "Channel",
-      "name": "nixos-25.11",
-      "url": "https://releases.nixos.org/nixos/25.11/nixos-25.11.1056.d9bc5c7dceb3/nixexprs.tar.xz",
-      "hash": "148dkksh8z1amk7jvp0a79k19aydxbzvhbhicbs41wwhkqk9yb57"
+      "name": "nixos-unstable",
+      "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre992384.549bd84d6279/nixexprs.tar.xz",
+      "hash": "172402zsy4kgw2nds4scmh53v3nal7p0arqmfl9jilh0lxj4vr59"
     }
   },
   "version": 5

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -60,9 +60,9 @@
     },
     "nixpkgs": {
       "type": "Channel",
-      "name": "nixos-unstable",
-      "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre992384.549bd84d6279/nixexprs.tar.xz",
-      "hash": "172402zsy4kgw2nds4scmh53v3nal7p0arqmfl9jilh0lxj4vr59"
+      "name": "nixos-26.05",
+      "url": "https://releases.nixos.org/nixos/26.05/nixos-26.05.1947.a0374025a863/nixexprs.tar.xz",
+      "hash": "13acdfkryy995aqwjibkfp9rsysaz0jjnf994h21d4mmz46m311y"
     }
   },
   "version": 5


### PR DESCRIPTION
26.05 will be released in less than 30 days if everything goes well.

We can use this amount of time as breaking changes are now restricted to
ensure there's no regression.

The strategy therefore is to bump Sécurix to 26.05 via the unstable channel, once 26.05 is out there, a proper channel 26.05 will exist and we can switch back to it.

Signed-off-by: Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>