### PR TITLE
Fix split email in self module

### DIFF
--- a/modules/self.nix
+++ b/modules/self.nix
@@ -23,13 +23,15 @@ let
     mkIf
     optionalString
     mkRenamedOptionModule
+    head
     ;
   deriveUsernameFromEmail =
     email:
     let
-      parts = splitString "." email;
-      firstName = elemAt 0 parts;
-      lastName = elemAt 1 parts;
+      localPart = head (splitString "@" email);
+      parts = splitString "." localPart;
+      firstName = elemAt parts 0;
+      lastName = elemAt parts 1;
       firstLetter = substring 0 1 firstName;
       usernameLimit = 32;
     in


### PR DESCRIPTION
This fix addresses two issues:

* The `splitString "."` on the email could incorrectly capture the `@`.
  `john.doe@domain.tld` -> `john`, `doe@domain`
* The argument order for [`elemAt`](https://noogle.dev/f/lib/lists/elemAt/) was most likely reversed.

To test quickly:

```sh
nix-instantiate --eval --strict -E '
let
  pkgs = import (import ./npins).nixpkgs {};
  inherit (pkgs) lib;
  selfModule = import ./modules/self.nix;
  eval = lib.evalModules {
    modules = [
      selfModule
      {
        _module.args.vpnProfiles = {};
        _module.check = false;
      }
      {
        securix.self = {
          mainDisk = "/dev/nvme0n1";
          edition = "test";
          user.email = "prenom.nom@domaine.tld";
          machine = {
            hardwareSKU = "x280";
            serialNumber = "000000";
          };
        };
      }
    ];
  };
in {
  username = eval.config.securix.self.user.username;
}
'
```

It should normally produce:

```nix
{ username = "pnom"; }
```

NB: It might make sense to move this kind of processing into a dedicated library, using testable helper functions. That would make the algorithm more robust and allow handling additional cases, for example email addresses that do not follow the "firstname.lastname..." pattern.