### PR TITLE
Removed sudo with empty user

### DIFF
--- a/modules/updates/automatic-pull.nix
+++ b/modules/updates/automatic-pull.nix
@@ -84,7 +84,7 @@ in
                         notify-send "$title" "$message" || true
                 else
                     # Terminal notification for non-GUI sessions
-                    sudo -u "$user" echo "$title: $message" | wall
+                    echo "$title: $message" | wall
                 fi
             done
           }


### PR DESCRIPTION
Probably a sudo with empty `$user`.