### PR TITLE
Auto-pull -> not restart on exit 103

### DIFF
--- a/modules/updates/automatic-pull.nix
+++ b/modules/updates/automatic-pull.nix
@@ -146,6 +146,7 @@ in
           100
           101
           102
+          103
         ];
         Environment = [
           "SSH_AUTH_SOCK=/var/tmp/ssh-tpm-agent.sock"


### PR DESCRIPTION
On line 123, we use `exit 103`, which could occur if there is a divergence with `BASE` for `REMOTE` and `LOCAL` simultaneously. This addition should prevent the service from restarting on this error code.