### PR TITLE
Fix ruleId key presence test

### DIFF
--- a/modules/anssi/generator.nix
+++ b/modules/anssi/generator.nix
@@ -53,7 +53,7 @@
           exceptionRationale = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default =
-              if config.security.anssi.exceptions ? ${rule.name} then
+              if config.security.anssi.exceptions ? ${ruleId} then
                 config.security.anssi.exceptions.${ruleId}.rationale
               else
                 null;


### PR DESCRIPTION
Test the `ruleId` key instead of `rule.name` to retrieve `rational`.

A `hasAttrByPath` would also allow us to check the `rational` key, unless we are certain that all `security.anssi.exceptions` have a `rational` (base.nix).