### PR TITLE
!= instead of -ne for non-numeric values

### DIFF
--- a/modules/anssi/kernel-options.nix
+++ b/modules/anssi/kernel-options.nix
@@ -9,7 +9,7 @@ let
       mkCheckSingularSysctl = attr: expectedValue: ''
         # Check for sysctl '${attr}'
         actual_value=$(sysctl -n "${attr}")
-        if [[ "$actual_value" -ne "${toString expectedValue}" ]]; then
+        if [[ "$actual_value" != "${toString expectedValue}" ]]; then
           echo "Check failed for ${attr}: expected ${toString expectedValue}, got $actual_value"
           exit 1
         else


### PR DESCRIPTION
This test may not yield the desired result.