### PR TITLE
modules/boot/plymouth: init

### DIFF
--- a/modules/boot/default.nix
+++ b/modules/boot/default.nix
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+{ imports = [ ./plymouth.nix ]; }

--- a/modules/boot/plymouth.nix
+++ b/modules/boot/plymouth.nix
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.securix.boot.plymouth;
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    ;
+in
+{
+  options.securix.boot.plymouth = {
+    enable = mkEnableOption "plymouth boot screen";
+    logo = mkOption {
+      type = types.path;
+      default = "${pkgs.nixos-icons}/share/icons/hicolor/128x128/apps/nix-snowflake.png";
+      description = "Logo for Plymouth";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    boot = {
+      consoleLogLevel = lib.mkDefault 3;
+      initrd.verbose = false;
+      initrd.systemd.enable = true;
+      kernelParams = [
+        "quiet"
+        "splash"
+        "udev.log_priority=3"
+        "rd.systemd.show_status=auto"
+      ];
+
+      plymouth = {
+        enable = true;
+        font = "${pkgs.hack-font}/share/fonts/truetype/Hack-Regular.ttf";
+        inherit (cfg) logo;
+      };
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -50,5 +50,7 @@
     ./o11y
     # All the (default) filesystem definitions
     ./filesystems
+    # Options related to the boot screen, UI, etc.
+    ./boot
   ];
 }

--- a/tests/idempotent-autoinstall.nix
+++ b/tests/idempotent-autoinstall.nix
@@ -62,23 +62,22 @@ let
     };
   };
 
-  autoinstallPkg = lib.findFirst (
-    p: p.name or "" == "autoinstall-terminal"
-  ) (throw "autoinstall-terminal not found in installer packages") installer.config.environment.systemPackages;
+  autoinstallPkg =
+    lib.findFirst (p: p.name or "" == "autoinstall-terminal")
+      (throw "autoinstall-terminal not found in installer packages")
+      installer.config.environment.systemPackages;
 
 in
 pkgs.testers.nixosTest {
   name = "autoinstall-terminal-idempotent";
 
-  nodes.machine =
-    _:
-    {
-      virtualisation.emptyDiskImages = [ 4096 ];
-      environment.systemPackages = [
-        autoinstallPkg
-        pkgs.expect
-      ];
-    };
+  nodes.machine = _: {
+    virtualisation.emptyDiskImages = [ 4096 ];
+    environment.systemPackages = [
+      autoinstallPkg
+      pkgs.expect
+    ];
+  };
 
   testScript = ''
     import textwrap

--- a/tests/idempotent-autoinstall.nix
+++ b/tests/idempotent-autoinstall.nix
@@ -71,7 +71,7 @@ pkgs.testers.nixosTest {
   name = "autoinstall-terminal-idempotent";
 
   nodes.machine =
-    { ... }:
+    _:
     {
       virtualisation.emptyDiskImages = [ 4096 ];
       environment.systemPackages = [


### PR DESCRIPTION
This supports an initial version of Plymouth to have a nicer boot for
normal users.

Signed-off-by: Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>