### PR TITLE
fix(anssi/R3): unquote regex pattern in Secure Boot check

### DIFF
--- a/modules/anssi/preboot.nix
+++ b/modules/anssi/preboot.nix
@@ -70,7 +70,7 @@
           secure_boot_status=$(xxd -p -c 4 "$secure_boot_file")
 
           # Check if Secure Boot is enabled
-          if [[ "$secure_boot_status" =~ ".*01.*" ]]; then
+          if [[ "$secure_boot_status" =~ 01 ]]; then
             echo "Secure Boot is enabled."
             exit 0
           else


### PR DESCRIPTION
Comme demandé par @rlahfa-dinum dans #128.
                                                                                                                  
`[[ "$status" =~ ".*01.*" ]]` testait une chaîne littérale (bash 3.2+ : motif entre guillemets = comparaison littérale, pas regex). Le retrait des guillemets autour de `01` corrige le faux négatif.

Closes #128.

## Test plan                                                                                                      
  
- [ ] `nix flake check`                                                                                           
- [ ] `anssi-nixos-compliance-check` sur un hôte avec Secure Boot activé : R3 retourne `pass`
- [ ] Même check sur un hôte avec Secure Boot désactivé : R3 retourne `fail`