### PR TITLE
refactor: generalized NetworkManager reaction API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+<!-- 
+SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Unreleased
+
+## Breaking
+
+- `availableHttpProxies` definition in `vpnProfiles` is deprecated, if you were using this option, you can replace it by something along these lines:
+
+  ```nix
+  services.automatic-http-proxy.networkmanager.events.handlers = {
+    "10-ipsec-proxies" = {
+      matchConnectionID = "VPN myvpn for $user";
+      proxyToActuate = "myproxy";
+    };
+  };
+  ```
+
+  The advantage of this method is that you can refer to the context of the
+  Securix system and do not suffer from
+  https://github.com/cloud-gouv/securix/issues/195 limitations.

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -52,5 +52,8 @@
     ./filesystems
     # Options related to the boot screen, UI, etc.
     ./boot
+    # React to NetworkManager events (low-level API)
+    # Used to turn on proxies in response to certain VPNs lifecycles.
+    ./networkmanager-events.nix
   ];
 }

--- a/modules/http-proxy/automatic.nix
+++ b/modules/http-proxy/automatic.nix
@@ -17,7 +17,23 @@ let
     mapAttrs
     filterAttrs
     types
+    concatMapAttrs
     ;
+
+  handlerOpts = _: {
+    options = {
+      matchConnectionId = mkOption {
+        type = types.str;
+        description = "Connection ID to match this handler with.";
+        example = "VPN ipsec for jdoe";
+      };
+      proxyToActuate = mkOption {
+        type = types.str;
+        description = "Name of the proxy to actuate (turn on / turn off in response to VPN events)";
+        example = "office";
+      };
+    };
+  };
 
   httpProxyOpts = _: {
     options = {
@@ -99,6 +115,7 @@ in
     enable = mkEnableOption "configure des proxies HTTP automatiquement";
 
     proxies = mkOption { type = types.attrsOf (types.submodule httpProxyOpts); };
+    networkmanager.events.handlers = mkOption { type = types.attrsOf (types.submodule handlerOpts); };
   };
 
   config = mkIf cfg.enable {
@@ -109,6 +126,46 @@ in
         _: { remote, ... }: "${remote.address}:${toString remote.port}"
       ) cfg.proxies;
     };
+
+    securix.networkmanager.events.handlers = concatMapAttrs (
+      eventName:
+      { matchConnectionId, proxyToActuate }:
+      let
+        proxyMetadata =
+          cfg.proxies.${proxyToActuate}
+            or (throw "Proxy '${proxyToActuate}' is not defined in the list of automatically managed proxies");
+      in
+      {
+        "${eventName}-up" = {
+          event = "vpn-up";
+          inherit matchConnectionId;
+
+          script = ''
+            # Hook for proxy ${proxyToActuate} related to VPN ${proxyMetadata.vpn}
+            # For connection ID: ${matchConnectionId}
+            logger "[Generic proxy hook] Automatically switching to proxy ${proxyToActuate}"
+            ${pkgs.proxy-switcher}/bin/proxy-switcher ${proxyToActuate} --cli
+            # TODO: only run this if the auth method uses ssh tunnels.
+            systemctl --user -M "$user"@ stop "ssh-tunnel-to-*" --all
+            systemctl --user -M "$user"@ start ssh-tunnel-to-${proxyToActuate}.service
+          '';
+        };
+
+        "${eventName}-down" = {
+          event = "vpn-down";
+          inherit matchConnectionId;
+
+          script = ''
+            # Hook for proxy ${proxyToActuate}
+            # For connection ID: ${matchConnectionId}
+            logger "[Generic proxy hook] Automatically switching to no proxy"
+            ${pkgs.proxy-switcher}/bin/proxy-switcher np
+            # TODO: only run this if the auth method uses ssh tunnels.
+            systemctl --user -M "$user"@ stop "ssh-tunnel-to-${proxyToActuate}.service"
+          '';
+        };
+      }
+    ) cfg.networkmanager.events.handlers;
 
     securix.ssh-tunnels = mapAttrs mkSSHTunnel (
       filterAttrs (_: { auth, ... }: auth.sshForward.enable) cfg.proxies

--- a/modules/networkmanager-events.nix
+++ b/modules/networkmanager-events.nix
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.securix.networkmanager.events;
+  inherit (lib)
+    mkOption
+    types
+    mkIf
+    mkEnableOption
+    concatStringsSep
+    attrNames
+    sort
+    ;
+
+  sortedHandlerNames = sort (a: b: a < b) (attrNames cfg.handlers);
+  mkHandlerScript =
+    name:
+    {
+      event,
+      matchConnectionId,
+      script,
+    }:
+    ''
+      if [[ "$event" == "${event}" && "$CONNECTION_ID" == "${matchConnectionId}" ]]; then
+        logger "[securix-nm-events-hook] running handler ${name}..."
+        ${script}
+      fi
+    '';
+in
+{
+  options.securix.networkmanager.events = {
+    enable = mkEnableOption "an event-based system to respond to NetworkManager events";
+
+    handlers = mkOption {
+      type = types.attrsOf (
+        types.submodule {
+          options = {
+            event = mkOption {
+              type = types.enum [
+                "vpn-up"
+                "vpn-down"
+              ];
+              description = "NetworkManager event type to handle";
+            };
+
+            matchConnectionId = mkOption {
+              type = types.str;
+              description = ''
+                Shell pattern to match against connection ID.
+
+                You can use `$user` as a placeholder to refer to the user who emitted that event.
+                This user is calculated on a best effort basis based on who is the graphical user connected to the system.
+              '';
+            };
+
+            script = mkOption {
+              type = types.lines;
+              description = "Shell script to execute when event matches";
+            };
+          };
+        }
+      );
+      default = { };
+      description = "Event handlers for NetworkManager dispatcher";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.networkmanager.dispatcherScripts = [
+      {
+        type = "basic";
+        source = pkgs.writeText "10-securix-nm-events-hook" ''
+          # This retrieves the caller user of the dispatcher.
+          # NOTE(Ryan): this logic is brittle. on a multi-seat system,
+          # there's multiple results.
+          # NetworkManager should pass who sent the D-Bus message as an environment variable.
+          # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/work_items/1976
+          user=$(loginctl list-sessions --no-legend | ${pkgs.gawk}/bin/awk '{print $3}' | sort -u | grep -vE '^(root|gdm)$')
+
+          if [[ "$2" != "vpn-up" && "$2" != "vpn-down" ]]; then
+            logger "[securix-nm-events-hook] exit: event $2, waiting for vpn-up or vpn-down event"
+            exit
+          fi
+
+          logger "[securix-nm-events-hook] evaluating all handlers..."
+          event="$2"
+          ${concatStringsSep "\n" (map (name: mkHandlerScript name cfg.handlers.${name}) sortedHandlerNames)}
+        '';
+      }
+    ];
+  };
+}

--- a/modules/vpn/ipsec/networkmanager.nix
+++ b/modules/vpn/ipsec/networkmanager.nix
@@ -56,6 +56,7 @@ let
         )
     )
   ) operators;
+  defaultProxiesPerVPN = filterAttrs (n: arg: arg.default or false) ipsecProxies;
   mkIPsecConnectionProfile =
     operatorName:
     {
@@ -176,7 +177,11 @@ in
   ];
 
   config = mkIf cfg.enable {
-    # TODO: warn if ipsecProxies is non-empty to push for deprecation.
+    warnings = lib.optional (defaultProxiesPerVPN != { }) ''
+      Some proxies were specified via `availableHttpProxies` in your VPN profiles. This method is deprecated.
+      Migrate to `securix.automatic-http-proxy.networkmanager.events.handlers` to activate proxy automatically in response to declared VPN profiles.
+      Please consult Sécurix changelog for more information.
+    '';
 
     age.secrets = mapAttrs (_: path: { file = path; }) cfg.secretsPaths;
 
@@ -227,21 +232,17 @@ in
     securix.automatic-http-proxy = {
       enable = mkDefault true;
       proxies = ipsecProxies;
-      networkmanager.events.handlers =
-        let
-          defaultProxiesPerVPN = filterAttrs (n: arg: arg.default or false) ipsecProxies;
-        in
-        mapAttrs' (
-          proxyName:
-          { vpn, ... }:
-          {
-            name = "10-securix-ipsec-${vpn}";
-            value = {
-              matchConnectionId = "VPN ${vpn} for $user";
-              proxyToActuate = proxyName;
-            };
-          }
-        ) defaultProxiesPerVPN;
+      networkmanager.events.handlers = mapAttrs' (
+        proxyName:
+        { vpn, ... }:
+        {
+          name = "10-securix-ipsec-${vpn}";
+          value = {
+            matchConnectionId = "VPN ${vpn} for $user";
+            proxyToActuate = proxyName;
+          };
+        }
+      ) defaultProxiesPerVPN;
     };
 
     networking.networkmanager.plugins = [ pkgs.networkmanager_strongswan ];

--- a/modules/vpn/ipsec/networkmanager.nix
+++ b/modules/vpn/ipsec/networkmanager.nix
@@ -176,6 +176,8 @@ in
   ];
 
   config = mkIf cfg.enable {
+    # TODO: warn if ipsecProxies is non-empty to push for deprecation.
+
     age.secrets = mapAttrs (_: path: { file = path; }) cfg.secretsPaths;
 
     # This is an extra rule to allow any user to do `sudo pkill charon-nm` to reset the VPN state.
@@ -221,67 +223,26 @@ in
 
     # Add all available proxies and default proxies for
     # IPsec VPN profiles.
+    securix.networkmanager.events.enable = true;
     securix.automatic-http-proxy = {
       enable = mkDefault true;
       proxies = ipsecProxies;
-    };
-    # Automatically switch to the default proxy of the
-    # enabled VPN.
-    networking.networkmanager.dispatcherScripts =
-      let
-        defaultProxiesPerVPN = filterAttrs (n: arg: arg.default or false) ipsecProxies;
-        mkSwitchFor =
+      networkmanager.events.handlers =
+        let
+          defaultProxiesPerVPN = filterAttrs (n: arg: arg.default or false) ipsecProxies;
+        in
+        mapAttrs' (
           proxyName:
           { vpn, ... }:
-          ''
-            # Hook for ${vpn}
-            # Default proxy: ${proxyName}
-            if [[ "$CONNECTION_ID" == "VPN ${vpn} for $user" ]]; then
-              logger "[IPsec proxy hook] Automatically switching to proxy ${proxyName}"
-              ${pkgs.proxy-switcher}/bin/proxy-switcher ${proxyName} --cli
-              # FIXME(Ryan): this hardcodes the SSH forward method for this proxy.
-              # We should check if that's needed and perhaps encode `bringupLogic` as a property of the proxy.
-              systemctl --user -M "$user"@ stop "ssh-tunnel-to-*" --all
-              systemctl --user -M "$user"@ start ssh-tunnel-to-${proxyName}.service
-            else
-              logger "[IPsec proxy hook] Skipping ${proxyName} for $CONNECTION_ID as it doesn't match $user-${vpn}.nmconnection"
-            fi
-          '';
-      in
-      [
-        {
-          type = "basic";
-          source = pkgs.writeText "10-automatic-proxy-switch-up-hook" ''
-            if [ "$2" != "vpn-up" ]; then
-              logger "exit: event $2, waiting for a vpn-up event"
-              exit
-            fi
-
-            # This retrieves the caller user of the dispatcher.
-            # NOTE(Ryan): this logic is brittle. on a multi-seat system,
-            # there's multiple results.
-            # NetworkManager should pass who sent the D-Bus message as an environment variable.
-            user=$(loginctl list-sessions --no-legend | ${pkgs.gawk}/bin/awk '{print $3}' | sort -u | grep -vE '^(root|gdm)$')
-            ${concatStringsSep "\n" (mapAttrsToList mkSwitchFor defaultProxiesPerVPN)}
-          '';
-        }
-        {
-          type = "basic";
-          source = pkgs.writeText "20-automatic-proxy-switch-down-hook" ''
-            if [ "$2" != "vpn-down" ]; then
-              logger "exit: event $2, waiting for a vpn-down event"
-              exit
-            fi
-            # This retrieves the caller user of the dispatcher.
-            # NOTE(Ryan): this logic is brittle. on a multi-seat system,
-            # there's multiple results.
-            # NetworkManager should pass who sent the D-Bus message as an environment variable.
-            user=$(loginctl list-sessions --no-legend | ${pkgs.gawk}/bin/awk '{print $3}' | sort -u | grep -vE '^(root|gdm)$')
-            systemctl --user -M "$user"@ stop "ssh-tunnel-to-*" --all
-            ${pkgs.proxy-switcher}/bin/proxy-switcher np
-          '';
-        }
-      ];
+          {
+            name = "10-securix-ipsec-${vpn}";
+            value = {
+              matchConnectionId = "VPN ${vpn} for $user";
+              proxyToActuate = proxyName;
+            };
+          }
+        ) defaultProxiesPerVPN;
+    };
 
     networking.networkmanager.plugins = [ pkgs.networkmanager_strongswan ];
     networking.networkmanager.ensureProfiles.environmentFiles = mapAttrsToList (


### PR DESCRIPTION
We encountered some issues while rolling out Portail which is described in #195.

To get towards #195 and provide actual value immediately for Portail, we need to make it possible to implement different ways of turning on the proxy depending on the actual implementation of the proxy.

In the past, this was super coupled to IPsec because we were not able to see what would be the benefit of generalizing it. We have gained experience about in which direction we should go.

The intent is the following:

- low level API to set dispatcher in response to connection IDs (not necessarily VPNs) and to run arbitrary scripts (for now, only VPN events are supported)
- medium level API for proxies to turn on/turn off proxies in response to VPNs events, each proxy implementation will have its own script implementation.
- backward compatibility for the historical `availableHttpProxies` offered in `vpnProfiles` which is going to be deprecated henceforth and is suggested to migrate to a side declaration using the medium level API.