### PR TITLE
fix(portail): repair dynamic-updates dependency

### DIFF
--- a/modules/http-proxy/portail/default.nix
+++ b/modules/http-proxy/portail/default.nix
@@ -82,14 +82,11 @@ in
           "portail-rpc.socket"
           "portail.service"
         ];
-        requires = [
+        bindsTo = [
           "portail-rpc.socket"
           "portail.service"
         ];
-        partOf = [
-          "portail-rpc.socket"
-          "portail.service"
-        ];
+        wantedBy = [ "portail.service" ];
         path = [ config.services.portail.package ];
         serviceConfig = {
           DynamicUser = true;

--- a/tests/portail.nix
+++ b/tests/portail.nix
@@ -24,7 +24,15 @@ let
         securix.automatic-http-proxy = {
           enable = true;
           implementation = "portail";
-          proxies = { };
+          proxies = {
+            dyntest = {
+              definition = "dynamic";
+              remotePath = pkgs.writeText "secret" ''
+                ADDRESS=1.2.3.4
+                PORT=8080
+              '';
+            };
+          };
         };
       }
     ];
@@ -38,8 +46,14 @@ pkgs.testers.nixosTest {
     };
   };
   testScript = ''
-    securix_unbranded_000000.wait_for_unit("default.target")
-    securix_unbranded_000000.succeed("cat /etc/os-release | grep securix")
-    securix_unbranded_000000.wait_for_unit("portail.service")
+    import json
+
+    securix = securix_unbranded_000000
+    securix.wait_for_unit("default.target")
+    securix.succeed("cat /etc/os-release | grep securix")
+    securix.wait_for_unit("portail.service")
+    securix.succeed("systemctl restart portail.service")
+    securix.wait_for_unit("portail.service")
+    assert json.loads(securix.succeed("portail rpc --json list-backends"))[0]['spec'] is not None, "Specification did not get reloaded"
   '';
 }


### PR DESCRIPTION
If portail.service doesn't want portail-dynamic-updates to start, then it won't.

Let's move to BindsTo= which is a very strong binding of dependencies for Portail and the dynamic updates. The most important thing is `WantedBy=` on portail-dynamic-updates.service or putting a `Wants=` on portail.service, otherwise no one will pull
portail-dynamic-updates.service in a transaction and this will result in nothing happening.

A NixOS test is expanded to show that the problem is fixed by calling into a manual restart.