### PR TITLE
.github/CODEOWNERS: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @jdauphant-dinum @rlahfa-dinum
+
+# All changes to .github/CODEOWNERS must be approved by jdauphant-dinum.
+.github/CODEOWNERS @jdauphant-dinum


### PR DESCRIPTION
This is a simple proposal of the current way of working in the Sécurix repository.

I take care of the technical matters as a default codeowner and jdauphant is the administrator of this repository for any ACL updates and is a fallback for technical matters.