### PR TITLE
feat: expose tools through a module

### DIFF
--- a/modules/tools/default.nix
+++ b/modules/tools/default.nix
@@ -1,87 +1,105 @@
 # SPDX-FileCopyrightText: 2025 Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>
+# SPDX-FileContributor: 2026 Pamplemousse <xavier.maso@beta.gouv.fr>
 #
 # SPDX-License-Identifier: MIT
 
-{ pkgs, ... }: {
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  inherit (lib) mkEnableOption mkIf;
+
+  cfg = config.securix.tools;
+in
+{
   imports = [ ./firefox.nix ];
 
-  programs.mtr.enable = true;
+  options.securix.tools = {
+    enable = mkEnableOption "Install tools";
+  };
 
-  environment.systemPackages = with pkgs; [
-    # Text editors
-    vscodium
-    vim
-    # TPM2
-    tpm2-tools
-    # A TPM-backed agent for SSH keys
-    ssh-tpm-agent
-    # VNC remoting
-    tigervnc
-    # Some good terminals.
-    alacritty
-    # Uncomment when NixOS 25.05 is used.
-    # ghostty
-    kitty
-    tmux # Multiplexer
-    screen # Multiplexer
-    # Scripting
-    python3
-    gum # TUI scripting
-    # PKI
-    certstrap # Certificate bootstrap for CAs
-    openssl # Generic purpose certificate tooling
-    step-ca # CA tooling
-    opensc # PKCS#11 tooling
-    # Misc
-    termdown # Time counter
-    fd # `find` alternative.
-    ripgrep # super fast `grep`
-    ripgrep-all # multi-format fast `grep`
-    pwgen # Password generator.
-    rofi-rbw-wayland # Rofi menu for rbw.
-    tree # Tree display
-    gnupg # PGP
-    connect # for using ssh with a proxy
-    jq # Lightweight and flexible command-line JSON processor
-    yq-go # Same as jq but for YAML
-    # Git, the full tooling.
-    gitFull
-    git-lfs
-    git-absorb
-    git-gr
-    lazygit
-    jujutsu
-    # Serial console work.
-    minicom
-    picocom
-    # To send files securly to another endpoint.
-    magic-wormhole-rs
-    # iPXE / PXE operations
-    pixiecore
-    # Unzipping
-    unzip
-    # To calculate things
-    libqalculate
-    # Troubleshooting
-    iperf3
-    tcpdump
-    dnsutils
-    conntrack-tools
-    pwru # Packet, where are you? - eBPF tooling
-    strace
-    gdb
-    # Network calculators
-    sipcalc
-    ipv6calc
-    # D-Bus debugging
-    d-spy
-    # Offline documentation
-    #linux-manual
-    glibcInfo
-    man-pages
-    man-pages-posix
-    # Browser
-    firefox
-    qrencode
-  ];
+  config = mkIf cfg.enable {
+    programs.mtr.enable = true;
+
+    environment.systemPackages = with pkgs; [
+      # Text editors
+      vscodium
+      vim
+      # TPM2
+      tpm2-tools
+      # A TPM-backed agent for SSH keys
+      ssh-tpm-agent
+      # VNC remoting
+      tigervnc
+      # Some good terminals.
+      alacritty
+      # Uncomment when NixOS 25.05 is used.
+      # ghostty
+      kitty
+      tmux # Multiplexer
+      screen # Multiplexer
+      # Scripting
+      python3
+      gum # TUI scripting
+      # PKI
+      certstrap # Certificate bootstrap for CAs
+      openssl # Generic purpose certificate tooling
+      step-ca # CA tooling
+      opensc # PKCS#11 tooling
+      # Misc
+      termdown # Time counter
+      fd # `find` alternative.
+      ripgrep # super fast `grep`
+      ripgrep-all # multi-format fast `grep`
+      pwgen # Password generator.
+      rofi-rbw-wayland # Rofi menu for rbw.
+      tree # Tree display
+      gnupg # PGP
+      connect # for using ssh with a proxy
+      jq # Lightweight and flexible command-line JSON processor
+      yq-go # Same as jq but for YAML
+      # Git, the full tooling.
+      gitFull
+      git-lfs
+      git-absorb
+      git-gr
+      lazygit
+      jujutsu
+      # Serial console work.
+      minicom
+      picocom
+      # To send files securly to another endpoint.
+      magic-wormhole-rs
+      # iPXE / PXE operations
+      pixiecore
+      # Unzipping
+      unzip
+      # To calculate things
+      libqalculate
+      # Troubleshooting
+      iperf3
+      tcpdump
+      dnsutils
+      conntrack-tools
+      pwru # Packet, where are you? - eBPF tooling
+      strace
+      gdb
+      # Network calculators
+      sipcalc
+      ipv6calc
+      # D-Bus debugging
+      d-spy
+      # Offline documentation
+      #linux-manual
+      glibcInfo
+      man-pages
+      man-pages-posix
+      # Browser
+      firefox
+      qrencode
+    ];
+  };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Antoine Eiche <aei.ext@hackcyom.com>
+# SPDX-FileContributor: 2026 Xavier Maso <xavier.maso@beta.gouv.fr>
 #
 # SPDX-License-Identifier: MIT
 
@@ -7,4 +8,5 @@
   anssi-minimal = import ./anssi-minimal.nix { inherit pkgs libSecurix; };
   idempotent-autoinstall = import ./idempotent-autoinstall.nix { inherit pkgs libSecurix; };
   portail = import ./portail.nix { inherit pkgs libSecurix; };
+  tools = import ./tools.nix { inherit pkgs libSecurix; };
 }

--- a/tests/tools.nix
+++ b/tests/tools.nix
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 Pamplemousse <xavier.maso@beta.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+{ pkgs, libSecurix }:
+let
+  terminalWith =
+    {
+      name,
+      serialNumber,
+      extraSecurixConfig,
+    }:
+    {
+      inherit name;
+      userSpecificModule = { };
+      vpnProfiles = { };
+      modules = [
+        {
+          securix = {
+            graphical-interface.variant = "sway";
+            self = {
+              mainDisk = "/dev/nvme0n1";
+              machine = {
+                inherit serialNumber;
+                hardwareSKU = "x280";
+              };
+            };
+          }
+          // extraSecurixConfig;
+        }
+      ];
+    };
+
+  terminal-with-tools = libSecurix.mkTerminal (terminalWith {
+    name = "tools";
+    serialNumber = "000000";
+    extraSecurixConfig = {
+      tools.enable = true;
+    };
+  });
+  terminal-without-tools = libSecurix.mkTerminal (terminalWith {
+    name = "tools";
+    serialNumber = "000001";
+    extraSecurixConfig = { };
+  });
+in
+pkgs.testers.nixosTest {
+  name = "tools";
+  nodes = {
+    securix-unbranded-000000 = {
+      imports = terminal-with-tools.modules;
+    };
+    securix-unbranded-000001 = {
+      imports = terminal-without-tools.modules;
+    };
+  };
+  testScript = ''
+    securix_with_tools = securix_unbranded_000000
+    securix_without_tools = securix_unbranded_000001
+
+    securix_with_tools.wait_for_unit("default.target")
+    securix_without_tools.wait_for_unit("default.target")
+
+    securix_with_tools.succeed("vim --version")
+    securix_without_tools.fail("vim --version")
+  '';
+}


### PR DESCRIPTION
Installed tools are now behind a module with an disabled option by default.
This prevents installation of everything, while letting existing users easily get what they are used to.

One could go further and allow to install portions of that list using options;
For example
`securix.tools.documentation`
could install
```
# Offline documentation
#linux-manual
glibcInfo
man-pages
man-pages-posix
```
but I was doubting the utility of having semantically meaningfull categories while keeping flexibility.

This somewhat paves the way for #218 : one could adress this issue by creating an "essentials" category :thinking: 