### PR TITLE
Inject the repository commit id in boot menu entries

### DIFF
--- a/modules/updates/automatic-pull.nix
+++ b/modules/updates/automatic-pull.nix
@@ -16,6 +16,20 @@ let
     mkOption
     types
     ;
+  # nixos-rebuild is wrapped to add the repository HEAD commit id to the added boot menu entry.  
+  # Note the derivation produced by this nixos-rebuild wrapper then differs from the one produced from the repository itself since it injects the commit id via builtins.getEnv.
+  nixos-rebuild-wrapped = pkgs.writeShellApplication {
+    name = "nixos-rebuild-wrapped";
+    runtimeInputs = [
+      pkgs.nixos-rebuild
+      pkgs.git
+    ];
+    text = ''
+      revision=$(git rev-parse HEAD)
+      export NIXOS_LABEL_VERSION="''${revision:0:7}"
+      nixos-rebuild "$@"
+    '';
+  };
 in
 {
   options.securix.auto-updates = {
@@ -54,7 +68,7 @@ in
         pkgs.gawk
         pkgs.libnotify
         pkgs.sudo
-        pkgs.nixos-rebuild
+        nixos-rebuild-wrapped
       ];
       script = ''
         _notify_current_user() {
@@ -126,7 +140,7 @@ in
             git pull || exit 1
 
             _notify_current_user "[Sécurix] Mises à jour" "Le code de votre système a été mis à jour. La reconstruction de votre système en arrière plan va commencer."
-            nixos-rebuild boot --attr terminals."${config.securix.self.machine.identifier}".system
+            nixos-rebuild-wrapped boot --attr terminals."${config.securix.self.machine.identifier}".system
             _notify_current_user "[Sécurix] Mises à jour" "La reconstruction du système est complète, au prochain redémarrage, votre système sera mis à jour."
           else
             echo "Repository does not exist, cloning..."
@@ -136,7 +150,7 @@ in
             git clone "$REPO_URL" "$REPO_DIR" -b "${cfg.branch}" || (_notify_current_user "[Sécurix] Mises à jour" "Initialisation échoué; est-ce que votre TPM2 est correctement onboardé?"; exit 1) && _notify_current_user "[Sécurix] Mises à jour" "Initialisation réussie. Reconstruction du système..."
 
             cd "$REPO_DIR/$REPO_SUBDIR" || exit 1
-            nixos-rebuild boot --attr terminals."${config.securix.self.machine.identifier}".system
+            nixos-rebuild-wrapped boot --attr terminals."${config.securix.self.machine.identifier}".system
             _notify_current_user "[Sécurix] Mises à jour" "La reconstruction du système est complète, au prochain redémarrage, votre système sera mis à jour."
           fi
       '';

--- a/modules/updates/automatic-pull.nix
+++ b/modules/updates/automatic-pull.nix
@@ -54,7 +54,7 @@ in
         pkgs.gawk
         pkgs.libnotify
         pkgs.sudo
-        pkgs.nixos-rebuild
+        pkgs.nixos-rebuild-git-aware
       ];
       script = ''
         _notify_current_user() {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ callPackage }: {
+{ callPackage, nixos-rebuild }: {
   mkPlasmaLookAndFeelPackage = callPackage ./plasma/mk-look-and-feel-package.nix { };
   plasma-portail-tray-icon = callPackage ./plasma/portail-tray-icon { };
+  nixos-rebuild = callPackage ./nixos-rebuild { inherit nixos-rebuild; };
+  nixos-rebuild-unwrapped = nixos-rebuild;
 }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,9 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-{ callPackage, nixos-rebuild }: {
+{ callPackage }: {
   mkPlasmaLookAndFeelPackage = callPackage ./plasma/mk-look-and-feel-package.nix { };
   plasma-portail-tray-icon = callPackage ./plasma/portail-tray-icon { };
-  nixos-rebuild = callPackage ./nixos-rebuild { inherit nixos-rebuild; };
-  nixos-rebuild-unwrapped = nixos-rebuild;
+  nixos-rebuild-git-aware = callPackage ./nixos-rebuild-git-aware { };
 }

--- a/pkgs/nixos-rebuild-git-aware/default.nix
+++ b/pkgs/nixos-rebuild-git-aware/default.nix
@@ -4,6 +4,7 @@
 
 # nixos-rebuild is wrapped to add the repository HEAD commit id to the added boot menu entry.
 # Note the derivation produced by this nixos-rebuild wrapper then differs from the one produced from the repository itself since it injects the commit id via builtins.getEnv.
+# See https://github.com/nixos/nixpkgs/blob/ddce4d809a16b9f0614e76636063282f6fb02908/nixos/modules/misc/label.nix#L69 for details.
 {
   writeShellApplication,
   nixos-rebuild,
@@ -16,6 +17,10 @@ writeShellApplication {
     git
   ];
   text = ''
+    if [ "$(git rev-parse --is-inside-work-tree 2>&1)" != "true" ]; then
+        echo "error: the current directory must be a Git repository."
+        exit 1
+    fi
     revision=$(git rev-parse HEAD)
     export NIXOS_LABEL_VERSION="''${revision:0:7}"
     nixos-rebuild "$@"

--- a/pkgs/nixos-rebuild/default.nix
+++ b/pkgs/nixos-rebuild/default.nix
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Antoine Eiche <antoine.eiche@lewocorp.eu>
+#
+# SPDX-License-Identifier: MIT
+
+# nixos-rebuild is wrapped to add the repository HEAD commit id to the added boot menu entry.
+# Note the derivation produced by this nixos-rebuild wrapper then differs from the one produced from the repository itself since it injects the commit id via builtins.getEnv.
+{
+  writeShellApplication,
+  nixos-rebuild,
+  git,
+}:
+writeShellApplication {
+  name = "nixos-rebuild";
+  runtimeInputs = [
+    nixos-rebuild
+    git
+  ];
+  text = ''
+    revision=$(git rev-parse HEAD)
+    export NIXOS_LABEL_VERSION="''${revision:0:7}"
+    nixos-rebuild "$@"
+  '';
+}

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -2,4 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
-super: self: (import ./default.nix { inherit (super) callPackage; })
+final: prev:
+(import ./default.nix {
+  inherit (final) callPackage;
+  nixos-rebuild = prev.nixos-rebuild;
+})

--- a/pkgs/overlay.nix
+++ b/pkgs/overlay.nix
@@ -2,8 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-final: prev:
-(import ./default.nix {
-  inherit (final) callPackage;
-  nixos-rebuild = prev.nixos-rebuild;
-})
+final: prev: (import ./default.nix { inherit (final) callPackage; })


### PR DESCRIPTION
For convenience, it allows to get the commit id from the boot menu, but this modifies the derivation produced by nixos-rebuild since the commit id is injected via the builtins.getEnv.