### PR TITLE
docs: how to build the documentation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -63,6 +63,9 @@ in
     pkgs = pkgs';
     libSecurix = lib-securix;
   };
+  docs = pkgs.runCommand "docs" { } ''
+    ${pkgs.mdbook}/bin/mdbook build ${./docs/manual} --dest-dir $out
+  '';
   shell = pkgs'.mkShell {
     packages = [
       pkgs'.npins

--- a/docs/manual/src/SUMMARY.md
+++ b/docs/manual/src/SUMMARY.md
@@ -27,6 +27,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Contributor guide
 
+- [How to contribute to the documentation](./contributor/docs.md)
 - [Testing]()
   - [How to test my changes in a virtual machine?]()
   - [How to test my changes on a real machine?]()

--- a/docs/manual/src/contributor/docs.md
+++ b/docs/manual/src/contributor/docs.md
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2026 Antoine Eiche <antoine.eiche@lewocorp.eu>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# How to build and render the documentation
+
+To build and render the documentation:
+```
+nix-build -A docs
+xdg-open ./result/index.html
+```


### PR DESCRIPTION
Expose a Nix attribute to easily build it:
```
nix-build -A docs
xdg-open ./result/index.html
```

This could also be used by the CI in order to publish it.