### PR TITLE
Feat: add option to chromium recommended policies

### DIFF
--- a/modules/chromium/default.nix
+++ b/modules/chromium/default.nix
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Pauline Legrand <pauline.legrand@numerique.gouv.fr>
+#
+# SPDX-License-Identifier: MIT
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.chromium;
+in
+
+{
+  ###### interface
+
+  options = {
+    programs.chromium = {
+      extraOptsRecommended = lib.mkOption {
+        type = lib.types.attrs;
+        description = ''
+          Extra chromium policy options in recommended. A list of available policies
+          can be found in the Chrome Enterprise documentation:
+          <https://cloud.google.com/docs/chrome-enterprise/policies/>
+          Make sure the selected policy is supported on Linux and your browser version.
+        '';
+        default = { };
+        example = lib.literalExpression ''
+          {
+            "BrowserSignin" = 0;
+            "SyncDisabled" = true;
+            "PasswordManagerEnabled" = false;
+            "SpellcheckEnabled" = true;
+            "SpellcheckLanguage" = [
+              "de"
+              "en-US"
+            ];
+          }
+        '';
+      };
+    };
+  };
+
+  ###### implementation
+
+  config = {
+    environment.etc = lib.mkIf cfg.enable {
+      "chromium/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
+        text = builtins.toJSON cfg.extraOptsRecommended;
+      };
+      "opt/chrome/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
+        text = builtins.toJSON cfg.extraOptsRecommended;
+      };
+      "brave/policies/recommended/extra.json" = lib.mkIf (cfg.extraOptsRecommended != { }) {
+        text = builtins.toJSON cfg.extraOptsRecommended;
+      };
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -57,5 +57,7 @@
     # React to NetworkManager events (low-level API)
     # Used to turn on proxies in response to certain VPNs lifecycles.
     ./networkmanager-events.nix
+    # For upstream https://github.com/NixOS/nixpkgs/pull/551055
+    ./chromium
   ];
 }


### PR DESCRIPTION
Temporary addition of the `programs.chromium.extraOptsRecommended` option.

This is a temporary workaround. I have opened a PR on `https://github.com/NixOS/nixpkgs/pull/551055` to add this feature upstream. While we wait for it to be merged, this module allows us to use it right away in our project. It generates the `recommended/extra.json` configuration files (for Chromium, Chrome, and Brave) to provide default settings that users can override in their browser.