### PR TITLE
feat(vpn/wireguard): display the public key as a QR code

### DIFF
--- a/modules/vpn/wireguard/README.md
+++ b/modules/vpn/wireguard/README.md
@@ -68,7 +68,9 @@ Once your VPN profile is installed, use the following commands to manage it:
 
 - `wireguard-<vpn-name>-pubkey`  
   Computes the corresponding public key from the generated private key.  
-  Useful for sharing with VPN peers.
+  Useful for sharing with VPN peers.  
+  The key is printed as text and also rendered as a scannable QR code, so it can
+  be transferred to the peer side without retyping it.
 
 - `wireguard-<vpn-name> up`  
   Activates the VPN using the private key decrypted by the YubiKey.

--- a/modules/vpn/wireguard/default.nix
+++ b/modules/vpn/wireguard/default.nix
@@ -42,6 +42,7 @@ let
   ykman = "${pkgs.yubikey-manager}/bin/ykman";
   age = "${pkgs.age}/bin/age";
   age-yubikey = "${pkgs.age-plugin-yubikey}/bin/age-plugin-yubikey";
+  qrencode = "${pkgs.qrencode}/bin/qrencode";
 
   # Create users scripts to run
   mkWireGuardScripts =
@@ -112,8 +113,20 @@ let
         ${importkey}/bin/wireguard-${wireguardName}-importkey <(${wg} genkey)
       '';
 
+      # The key is computed once and bound to a variable because it is now needed
+      # twice: the private key is read from the YubiKey, whose touch policy is
+      # `always`, so recomputing it would ask for a second touch.
+      #
+      # ANSIUTF8 rather than UTF8: UTF8 emits no colour escape at all, so the
+      # blocks take the terminal palette and the code comes out inverted on a
+      # light background, which most phone scanners reject. ANSIUTF8 pins the
+      # colours (black background, bright white blocks), keeping the polarity
+      # correct on every theme.
       pubkey = pkgs.writeShellScriptBin "wireguard-${wireguardName}-pubkey" ''
-        echo "The wireguard public key is: $(${private-key} | ${wg} pubkey)"
+        pub=$(${private-key} | ${wg} pubkey)
+        echo "The wireguard public key is: $pub"
+        echo
+        ${qrencode} -t ANSIUTF8 -- "$pub"
       '';
 
       importkey = pkgs.writeShellScriptBin "wireguard-${wireguardName}-importkey" ''


### PR DESCRIPTION
## What

`wireguard-<vpn-name>-pubkey` now renders the WireGuard public key as a QR code, below the text it already prints.

## Why

Registering a machine with a VPN peer means moving a 44-character base64 key across machines by hand. A scannable code removes the retyping, and the typos that come with it.

`importkey` already calls `pubkey`, so the QR code also shows up right after key generation, which is where it is most useful. No new dependency is introduced: `qrencode` is already part of the project's package set in `modules/tools/default.nix`.

## Implementation notes

**`-t ANSIUTF8` rather than `-t UTF8`.** `UTF8` emits no colour escape at all, so the blocks take the terminal's own palette; on a light background the quiet zone renders dark, the code is inverted, and most phone scanners refuse to read it. `ANSIUTF8` emits `\e[40;37;1m`, pinning background and foreground, so the polarity stays correct on any theme.

**The key is bound to a shell variable** instead of being computed twice. The private key is read from the YubiKey, whose touch policy is `always` (set in `importkey` via `--touch-policy always`), so a second call would ask for another physical touch to run a single command.

## Testing

Verified locally:

- `nixfmt -sc`, `statix check --config statix.toml` and `reuse --root . lint` all pass — the same commands the CI workflows run.
- The `pubkey` derivation builds. The module was instantiated on its own with a dummy WireGuard profile and the generated script inspected: `qrencode` resolves to a store path, so it does not rely on `$PATH`.
- QR round-trip: a throwaway key (`wg genkey | wg pubkey`) encoded with the `qrencode` version pinned by the derivation, then decoded back with `zbarimg`, returns the identical 44-character string.
- The `ANSIUTF8` output was scanned with a phone from a terminal, on both a light and a dark theme.

Not verified: the full path through the YubiKey, for lack of the hardware. That path is untouched by this PR — the only new code is the two lines after `wg pubkey`.

I did not run `nix-build -A tests` locally: no test in `tests/` enables `securix.vpn.wireguard`, so the suite would not exercise this code path. Happy to add a test if you would like one.

Closes #223
