### PR TITLE
ci: skip the binary cache setup when credentials are unavailable

### DIFF
--- a/.github/workflows/securix-testsuite.yaml
+++ b/.github/workflows/securix-testsuite.yaml
@@ -1,10 +1,16 @@
 jobs:
   tests:
     runs-on: ubuntu-latest
+    # Secrets are not exposed to workflows triggered by a pull request opened
+    # from a fork. Without credentials, every request to the S3 substituter is
+    # rejected, so the cache is only configured when they are available.
+    env:
+      HAS_CACHE_CREDENTIALS: ${{ secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_KEY != '' && secrets.NIX_SIGNING_PRIVATE_KEY != '' }}
     steps:
     - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
     - uses: samueldr/lix-gha-installer-action@f526e761e1ad201b0f4231f61a2a569f17bcc2ac # main
     - uses: zombiezen/setup-nix-cache-action@cacc7abf0a6636b0ef45ec2ae055a9734cdd4122 # main
+      if: env.HAS_CACHE_CREDENTIALS == 'true'
       with:
         substituters: s3://oss-securix?endpoint=https://s3.gra.io.cloud.ovh.net&region=gra&compression=xz&parallel-compression=true
         secret_keys: ${{ secrets.NIX_SIGNING_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

The `[Sécurix] Test suite` workflow fails on every pull request opened from a fork, regardless of the change it carries:

```
post-build-hook: error: AWS error fetching 'nix-cache-info': Unable to parse ExceptionName: InvalidRequest Message: Invalid Request.
error:
       … while running the post-build-hook /tmp/setup-nix-cache-action-…/post-build-hook for derivation /nix/store/…-test-script.drv
       error: program '/tmp/setup-nix-cache-action-…/post-build-hook' failed with exit code 123
```

GitHub does not expose repository secrets to workflows triggered by `pull_request` from a fork, so `NIX_SIGNING_PRIVATE_KEY`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY` are all empty strings. The S3 store then rejects every request, and the post-build hook takes `nix-build` down with it.

Two things make this hard to read from the outside:

- the failure comes from the upload hook, not from the build, so the job is red even though the derivations built fine;
- the job is green on internal branches, which makes it look like the contributed change is at fault.

Affected pull requests I could find: #228, #230, #231, #234, #235. Internal branches such as #233 are unaffected.

## Change

Guard the cache setup on the presence of the credentials. The `secrets` context is not available in an `if:` condition, so the check goes through a job-level `env` entry, which does have access to it.

- internal branches and pushes to `main`: unchanged, the cache is still read from and written to;
- forks: the cache step is skipped and the build runs against `cache.nixos.org` alone, so the job reports the actual result of the test suite.

## Note

`docs/manual/src/user/cache.md` already recommends separating an untrusted CI cache from a trusted CD cache for projects accepting external contributions. That would be the more complete answer here, but it needs bucket and secret changes that only maintainers can make. This patch only stops fork pull requests from reporting a failure they did not cause, and does not stand in the way of that approach.

## Verification

Since `pull_request` runs the workflow definition carried by the pull request, this one exercises the change directly: the fork path of the condition is what its own `Test suite` run goes through. The runs are held in `action_required` because the pull request touches `.github/workflows`, so approving them is the verification. A green `Test suite` here is the result the fix is meant to produce; the credentials-present path stays covered by `main` after merge.

Checked before opening:

- the S3 endpoint returns HTTP 400 for an unauthenticated read of `nix-cache-info`, confirming the bucket is unusable as a substituter without credentials, and that no read-only fallback is available;
- the `secrets` context is unavailable in `jobs.<job_id>.steps.if` but available in `jobs.<job_id>.env`, and the `env` context is available in `steps.if`, per the contexts reference;
- `secret_keys` is what drives the upload in `zombiezen/setup-nix-cache-action`, and the credentials are needed for downloads too, so skipping the whole step is the correct granularity;
- the file still parses as valid YAML with the expected condition on the expected step.
