### PR TITLE
.github/workflows: patch the post-build-hook

### DIFF
--- a/.github/workflows/securix-testsuite.yaml
+++ b/.github/workflows/securix-testsuite.yaml
@@ -10,6 +10,40 @@ jobs:
         secret_keys: ${{ secrets.NIX_SIGNING_PRIVATE_KEY }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_KEY }}
+    # Necessary until https://gerrit.lix.systems/c/lix/+/4995 lands in a released version.
+    - name: Patch post-build-hook with retry logic
+      run: |
+        HOOK_PATH=$(grep -Po '^post-build-hook\s*=\s*\K.*' /etc/nix/nix.conf) || true
+        if [ -z "$HOOK_PATH" ] || [ ! -x "$HOOK_PATH" ]; then
+          echo "No post-build-hook found, skipping patch."
+          exit 0
+        fi
+        ORIG_HOOK="${HOOK_PATH}.orig"
+        echo "Patching post-build-hook at $HOOK_PATH (backing up to $ORIG_HOOK)"
+        sudo mv "$HOOK_PATH" "$ORIG_HOOK"
+        sudo tee "$HOOK_PATH" > /dev/null <<'ENDOFSCRIPT'
+        #!/usr/bin/env bash
+        max_retries=10
+        attempt=0
+        delay=1
+        while true; do
+          if XXHOOKPATHXX "$@"; then
+            exit 0
+          fi
+          attempt=$((attempt + 1))
+          if [ $attempt -ge $max_retries ]; then
+            echo "post-build-hook failed after $max_retries attempts, giving up"
+            exit 1
+          fi
+          echo "post-build-hook attempt $attempt failed, retrying in ${delay}s..."
+          sleep $delay
+          delay=$((delay * 2))
+          [ $delay -gt 300 ] && delay=300
+        done
+        ENDOFSCRIPT
+        sudo sed -i "s|XXHOOKPATHXX|$ORIG_HOOK|" "$HOOK_PATH"
+        sudo chmod +x "$HOOK_PATH"
+        echo "Patched post-build-hook successfully."
     - name: Build tests
       run: nix-build -A tests
 name: '[Sécurix] Test suite'

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -444,7 +444,7 @@ rec {
         ../modules
         ../hardware
         # For Secure Boot.
-        (import sources.lanzaboote).nixosModules.lanzaboote
+        (import sources.lanzaboote { inherit pkgs; }).nixosModules.lanzaboote
         "${sources.portail}/nix/module.nix"
         "${sources.disko}/module.nix"
         "${sources.agenix}/modules/age.nix"

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -50,10 +50,10 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "v0.4.2",
-      "revision": "f0212638a2ec787a7841882f4477d40ae24f0a5d",
-      "url": "https://api.github.com/repos/nix-community/lanzaboote/tarball/v0.4.2",
-      "hash": "sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU="
+      "version": "v1.1.0",
+      "revision": "7c9a54a7f87b4539ddbd8bda09a8a5f5f9361aa9",
+      "url": "https://api.github.com/repos/nix-community/lanzaboote/tarball/refs/tags/v1.1.0",
+      "hash": "sha256-hqijVSEETttmo8Okql9/LG0Ua34hdciKW1a5zzlj8mU="
     },
     "nixpkgs": {
       "type": "Channel",


### PR DESCRIPTION
The post-build-hook continue to fail due to transient error on the OVH
side.

Additionally, we bump lanzaboote to v1.1.0, which should make all the deprecation warnings go away.

Signed-off-by: Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>