### PR TITLE
Various small features: install logs, SHA(serial number), preflight checks at install

### DIFF
--- a/.github/workflows/securix-testsuite.yaml
+++ b/.github/workflows/securix-testsuite.yaml
@@ -10,6 +10,40 @@ jobs:
         secret_keys: ${{ secrets.NIX_SIGNING_PRIVATE_KEY }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_KEY }}
+    # Necessary until https://gerrit.lix.systems/c/lix/+/4995 lands in a released version.
+    - name: Patch post-build-hook with retry logic
+      run: |
+        HOOK_PATH=$(grep -Po '^post-build-hook\s*=\s*\K.*' /etc/nix/nix.conf) || true
+        if [ -z "$HOOK_PATH" ] || [ ! -x "$HOOK_PATH" ]; then
+          echo "No post-build-hook found, skipping patch."
+          exit 0
+        fi
+        ORIG_HOOK="${HOOK_PATH}.orig"
+        echo "Patching post-build-hook at $HOOK_PATH (backing up to $ORIG_HOOK)"
+        sudo mv "$HOOK_PATH" "$ORIG_HOOK"
+        sudo tee "$HOOK_PATH" > /dev/null <<'ENDOFSCRIPT'
+        #!/usr/bin/env bash
+        max_retries=10
+        attempt=0
+        delay=1
+        while true; do
+          if XXHOOKPATHXX "$@"; then
+            exit 0
+          fi
+          attempt=$((attempt + 1))
+          if [ $attempt -ge $max_retries ]; then
+            echo "post-build-hook failed after $max_retries attempts, giving up"
+            exit 1
+          fi
+          echo "post-build-hook attempt $attempt failed, retrying in ${delay}s..."
+          sleep $delay
+          delay=$((delay * 2))
+          [ $delay -gt 300 ] && delay=300
+        done
+        ENDOFSCRIPT
+        sudo sed -i "s|XXHOOKPATHXX|$ORIG_HOOK|" "$HOOK_PATH"
+        sudo chmod +x "$HOOK_PATH"
+        echo "Patched post-build-hook successfully."
     - name: Build tests
       run: nix-build -A tests
 name: '[Sécurix] Test suite'

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -275,9 +275,15 @@ rec {
               (pkgs.writeShellScriptBin "autoinstall-terminal" ''
                         #!/usr/bin/env bash
 
+                        INSTALL_LOG="/tmp/install.log"
+                        touch "$INSTALL_LOG"
+
                         log() {
                           local level="$1"
                           local msg="$2"
+                          local timestamp
+                          timestamp=$(date -Iseconds)
+                          echo "[$timestamp] [$level] $msg" >> "$INSTALL_LOG"
                           case "$level" in
                             info)
                               ${pkgs.gum}/bin/gum log -t rfc822 -l info "$msg"
@@ -355,6 +361,12 @@ rec {
                         ${postInstallScript}
                         lsblk
                         log_info "Installation is complete. You can now reboot in the installed system."
+
+                        if [ -f "$install_log" ]; then
+                          mkdir -p /mnt/var/log
+                          cp "$INSTALL_LOG" /mnt/var/log/securix-install.log
+                          log_info "Install log saved to /var/log/securix-install.log on the target system."
+                        fi
               '')
             ];
           }

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -444,7 +444,7 @@ rec {
         ../modules
         ../hardware
         # For Secure Boot.
-        (import sources.lanzaboote).nixosModules.lanzaboote
+        (import sources.lanzaboote { inherit pkgs; }).nixosModules.lanzaboote
         "${sources.portail}/nix/module.nix"
         "${sources.disko}/module.nix"
         "${sources.agenix}/modules/age.nix"

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -45,6 +45,7 @@ let
     secureBoot = "self-contained";
     tpm2HostKeys = true;
     ageHostKeys = true;
+    skipPreflightChecks = false;
   };
 in
 rec {
@@ -336,6 +337,26 @@ rec {
                         lsblk
 
                         ${pkgs.systemd}/bin/udevadm settle
+
+                        ${lib.optionalString (preprovisionOptions.skipPreflightChecks or false) ''
+                          box_message "Preflight checks..."
+
+                          log_info "Checking for FIDO2 security keys..."
+                          if ${pkgs.yubikey-manager}/bin/ykman list 2>/dev/null | grep -q '.'; then
+                            log_info "FIDO2 key detected:"
+                            ${pkgs.yubikey-manager}/bin/ykman list 2>/dev/null | while read -r line; do
+                              log_info "  $line"
+                            done
+                          else
+                            log_error "No FIDO2 key detected."
+                            log_error "A FIDO2 security key is required."
+                            box_message "Installation aborted: Plug in your security key and retry."
+                            exit 1
+                          fi
+                        ''}
+
+                        box_message "All preflight checks passed."
+
                         log_info "${mainDisk} will be re-initialized and formatted, please confirm this is the right target."
                         ${pkgs.gum}/bin/gum confirm "Proceed with reformatting?" || { log_warn "Operation cancelled."; exit 0; }
 
@@ -362,11 +383,12 @@ rec {
                         lsblk
                         log_info "Installation is complete. You can now reboot in the installed system."
 
-                        if [ -f "$install_log" ]; then
+                        if [ -f "$INSTALL_LOG" ]; then
                           mkdir -p /mnt/var/log
                           cp "$INSTALL_LOG" /mnt/var/log/securix-install.log
                           log_info "Install log saved to /var/log/securix-install.log on the target system."
                         fi
+
               '')
             ];
           }

--- a/modules/admins/default.nix
+++ b/modules/admins/default.nix
@@ -38,7 +38,10 @@ let
     { name, ... }:
     nameValuePair name {
       isNormalUser = true;
-      extraGroups = [ "wheel" ];
+      extraGroups = [
+        "wheel"
+        "operator"
+      ];
     };
   mkAdminU2F = _: { name, u2f_keys, ... }: nameValuePair name u2f_keys;
 in

--- a/modules/self.nix
+++ b/modules/self.nix
@@ -23,6 +23,7 @@ let
     mkIf
     optionalString
     mkRenamedOptionModule
+    hashString
     ;
   deriveUsernameFromEmail =
     email:
@@ -41,7 +42,7 @@ let
     if cfg.machine.inventoryId != null then
       cfg.machine.inventoryId
     else if cfg.machine.serialNumber != null then
-      cfg.machine.serialNumber
+      substring 0 12 (hashString "sha256" cfg.machine.serialNumber)
     else
       "unknown machine";
 in

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -50,10 +50,10 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "v0.4.2",
-      "revision": "f0212638a2ec787a7841882f4477d40ae24f0a5d",
-      "url": "https://api.github.com/repos/nix-community/lanzaboote/tarball/v0.4.2",
-      "hash": "sha256-AEEDktApTEZ5PZXNDkry2YV2k6t0dTgLPEmAZbnigXU="
+      "version": "v1.1.0",
+      "revision": "7c9a54a7f87b4539ddbd8bda09a8a5f5f9361aa9",
+      "url": "https://api.github.com/repos/nix-community/lanzaboote/tarball/refs/tags/v1.1.0",
+      "hash": "sha256-hqijVSEETttmo8Okql9/LG0Ua34hdciKW1a5zzlj8mU="
     },
     "nixpkgs": {
       "type": "Channel",

--- a/tests/anssi-minimal.nix
+++ b/tests/anssi-minimal.nix
@@ -23,7 +23,7 @@ let
             mainDisk = "/dev/nvme0n1";
             machine = {
               hardwareSKU = "x280";
-              serialNumber = "000000";
+              inventoryId = 0;
             };
           };
         };
@@ -34,12 +34,12 @@ in
 pkgs.testers.nixosTest {
   name = "anssi-minimal";
   nodes = {
-    securix-unbranded-000000 = {
+    securix-unbranded-0 = {
       imports = terminal.modules;
     };
   };
   testScript = ''
-    securix_unbranded_000000.wait_for_unit("default.target")
-    securix_unbranded_000000.succeed("cat /etc/os-release | grep securix")
+    securix_unbranded_0.wait_for_unit("default.target")
+    securix_unbranded_0.succeed("cat /etc/os-release | grep securix")
   '';
 }

--- a/tests/idempotent-autoinstall.nix
+++ b/tests/idempotent-autoinstall.nix
@@ -56,6 +56,7 @@ let
     installScript = "echo 'install skipped for test'";
     preprovisionOptions = {
       secureBoot = "disabled";
+      skipPreflightCheck = true;
       tpm2HostKeys = false;
       ageHostKeys = false;
     };

--- a/tests/minimal.nix
+++ b/tests/minimal.nix
@@ -16,7 +16,7 @@ let
             mainDisk = "/dev/nvme0n1";
             machine = {
               hardwareSKU = "x280";
-              serialNumber = "000000";
+              inventoryId = 0;
             };
           };
         };
@@ -27,12 +27,12 @@ in
 pkgs.testers.nixosTest {
   name = "minimal";
   nodes = {
-    securix-unbranded-000000 = {
+    securix-unbranded-0 = {
       imports = terminal.modules;
     };
   };
   testScript = ''
-    securix_unbranded_000000.wait_for_unit("default.target")
-    securix_unbranded_000000.succeed("cat /etc/os-release | grep securix")
+    securix_unbranded_0.wait_for_unit("default.target")
+    securix_unbranded_0.succeed("cat /etc/os-release | grep securix")
   '';
 }

--- a/tests/portail.nix
+++ b/tests/portail.nix
@@ -16,7 +16,7 @@ let
             mainDisk = "/dev/nvme0n1";
             machine = {
               hardwareSKU = "x280";
-              serialNumber = "000000";
+              inventoryId = 0;
             };
           };
         };
@@ -41,14 +41,14 @@ in
 pkgs.testers.nixosTest {
   name = "portail";
   nodes = {
-    securix-unbranded-000000 = {
+    securix-unbranded-0 = {
       imports = terminal.modules;
     };
   };
   testScript = ''
     import json
 
-    securix = securix_unbranded_000000
+    securix = securix_unbranded_0
     securix.wait_for_unit("default.target")
     securix.succeed("cat /etc/os-release | grep securix")
     securix.wait_for_unit("portail.service")


### PR DESCRIPTION
- Install logs are now persisted in `/tmp/install.log` and `/var/log/securix-install.log` (post install). They do not contain all the logs, but it should be easy to add the stdout/stderr of various commands.
- The serial number information in the hostname is now replaced by the 12 first chars of the SHA256(serial number). Fixes #206.
- FIDO2 keys are now prechecked at install time and install won't proceed if it's not plugged.

Depends on #237.

Signed-off-by: Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>