### PR TITLE
config: delete latest kernel version to x9-15, e14-g7 and t14g6

### DIFF
--- a/hardware/e14-g7.nix
+++ b/hardware/e14-g7.nix
@@ -16,7 +16,6 @@ in
   imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
 
   config = mkIf (config.securix.self.machine.hardwareSKU == "e14-g7") {
-    boot.kernelPackages = pkgs.linuxPackages_latest;
     boot.initrd.availableKernelModules = [
       "xhci_pci"
       "thunderbolt"

--- a/hardware/t14g6.nix
+++ b/hardware/t14g6.nix
@@ -19,7 +19,6 @@ in
   imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
 
   config = mkIf (config.securix.self.machine.hardwareSKU == "t14g6") {
-    boot.kernelPackages = pkgs.linuxPackages_latest;
     boot.initrd.availableKernelModules = [
       "xhci_pci"
       "nvme"

--- a/hardware/x9-15.nix
+++ b/hardware/x9-15.nix
@@ -19,7 +19,6 @@ in
   imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
 
   config = mkIf (config.securix.self.machine.hardwareSKU == "x9-15") {
-    boot.kernelPackages = pkgs.linuxPackages_latest; # work only with 6.19.0-rc5
     boot.initrd.availableKernelModules = [
       "xhci_pci"
       "thunderbolt"


### PR DESCRIPTION
Use the kernel version from nixpkgs for greater stability and better reproducibility across different hardware.