### PR TITLE
tests/tools: set inventoryId so the hostname matches the QEMU node name

### DIFF
--- a/tests/tools.nix
+++ b/tests/tools.nix
@@ -58,7 +58,9 @@ pkgs.testers.nixosTest {
   };
   testScript = ''
     securix_with_tools = securix_unbranded_0
-    securix_without_tools = securix_unbranded_${builtins.substring 0 12 (builtins.hashString "sha256" "000001")}
+    securix_without_tools = securix_unbranded_${
+      builtins.substring 0 12 (builtins.hashString "sha256" "000001")
+    }
 
     securix_with_tools.wait_for_unit("default.target")
     securix_without_tools.wait_for_unit("default.target")

--- a/tests/tools.nix
+++ b/tests/tools.nix
@@ -8,6 +8,7 @@ let
     {
       name,
       serialNumber,
+      inventoryId,
       extraSecurixConfig,
     }:
     {
@@ -21,7 +22,7 @@ let
             self = {
               mainDisk = "/dev/nvme0n1";
               machine = {
-                inherit serialNumber;
+                inherit serialNumber inventoryId;
                 hardwareSKU = "x280";
               };
             };
@@ -34,6 +35,7 @@ let
   terminal-with-tools = libSecurix.mkTerminal (terminalWith {
     name = "tools";
     serialNumber = "000000";
+    inventoryId = 0;
     extraSecurixConfig = {
       tools.enable = true;
     };
@@ -41,22 +43,23 @@ let
   terminal-without-tools = libSecurix.mkTerminal (terminalWith {
     name = "tools";
     serialNumber = "000001";
+    inventoryId = 1;
     extraSecurixConfig = { };
   });
 in
 pkgs.testers.nixosTest {
   name = "tools";
   nodes = {
-    securix-unbranded-000000 = {
+    securix-unbranded-0 = {
       imports = terminal-with-tools.modules;
     };
-    securix-unbranded-000001 = {
+    securix-unbranded-1 = {
       imports = terminal-without-tools.modules;
     };
   };
   testScript = ''
-    securix_with_tools = securix_unbranded_000000
-    securix_without_tools = securix_unbranded_000001
+    securix_with_tools = securix_unbranded_0
+    securix_without_tools = securix_unbranded_1
 
     securix_with_tools.wait_for_unit("default.target")
     securix_without_tools.wait_for_unit("default.target")

--- a/tests/tools.nix
+++ b/tests/tools.nix
@@ -8,7 +8,7 @@ let
     {
       name,
       serialNumber,
-      inventoryId,
+      inventoryId ? null,
       extraSecurixConfig,
     }:
     {
@@ -43,7 +43,6 @@ let
   terminal-without-tools = libSecurix.mkTerminal (terminalWith {
     name = "tools";
     serialNumber = "000001";
-    inventoryId = 1;
     extraSecurixConfig = { };
   });
 in
@@ -53,13 +52,13 @@ pkgs.testers.nixosTest {
     securix-unbranded-0 = {
       imports = terminal-with-tools.modules;
     };
-    securix-unbranded-1 = {
+    "securix-unbranded-${builtins.substring 0 12 (builtins.hashString "sha256" "000001")}" = {
       imports = terminal-without-tools.modules;
     };
   };
   testScript = ''
     securix_with_tools = securix_unbranded_0
-    securix_without_tools = securix_unbranded_1
+    securix_without_tools = securix_unbranded_${builtins.substring 0 12 (builtins.hashString "sha256" "000001")}
 
     securix_with_tools.wait_for_unit("default.target")
     securix_without_tools.wait_for_unit("default.target")


### PR DESCRIPTION
`nix-build -A tests` has been red on main since #221.

`tests/tools.nix` names the QEMU nodes after the serial
(`securix-unbranded-000000`). Sécurix hostname uses `inventoryId`, or a
hash of the serial. Those strings do not match, so evaluation fails.

Set `inventoryId` 0 and 1 and name the nodes `securix-unbranded-0` and
`securix-unbranded-1`, same as `tests/minimal.nix`.