### PR TITLE
fix: Add git as a runtime input for upgrade script

### DIFF
--- a/modules/updates/permissionless-upgrade.nix
+++ b/modules/updates/permissionless-upgrade.nix
@@ -210,6 +210,8 @@ let
   upgradeScript = pkgs.writeShellApplication {
     name = "upgrade";
 
+    runtimeInputs = [ pkgs.git ];
+
     text = ''
       # Ensure the script runs as root
       if [ "$(id -u)" -ne 0 ]; then


### PR DESCRIPTION
## Problem

git have been removed on default installation

## Solution

Add git to script dependance