### PR TITLE
fix: ignore the `npins/` folder when checking formatting

### DIFF
--- a/.github/workflows/securix-check-formatting.yaml
+++ b/.github/workflows/securix-check-formatting.yaml
@@ -7,7 +7,7 @@ jobs:
     - name: Check for statix
       run: nix-shell --run 'statix check --config statix.toml'
     - name: Check for formatting
-      run: nix-shell --run 'nixfmt -sc $(find . -name "*.nix" -not -path "./npins" -not -path "./lib/default.nix")'
+      run: nix-shell --run 'nixfmt -sc $(find . -name "*.nix" -not -path "./npins/*" -not -path "./lib/default.nix")'
 name: '[Sécurix] Formatting check'
 on:
   pull_request:


### PR DESCRIPTION
Without globbing, `-path` matches an exact filepath. As such, `-not -path "./npins"` does NOT exclude the file `./npins/default.nix`, that does not necessarily respect our formatting.

```bash
$ find . -name "*.nix" -not -path "./npins" -not -path "./lib/default.nix" | rg npins
./npins/default.nix

$ find . -name "*.nix" -not -path "./npins*" -not -path "./lib/default.nix" | rg npins
# nothing
```

This PR repairs the filtering of files to check the formatting for.