### PR TITLE
tests/portail: fix the dyntest race condition

### DIFF
--- a/tests/portail.nix
+++ b/tests/portail.nix
@@ -34,6 +34,11 @@ let
             };
           };
         };
+
+        # Test-only: the oneshot exits fast enough that wait_for_unit sees it as
+        # "inactive, no pending jobs" more often than not, unless it stays active
+        # after a successful run.
+        systemd.services.portail-dynamic-updates.serviceConfig.RemainAfterExit = true;
       }
     ];
   };
@@ -54,6 +59,11 @@ pkgs.testers.nixosTest {
     securix.wait_for_unit("portail.service")
     securix.succeed("systemctl restart portail.service")
     securix.wait_for_unit("portail.service")
-    assert json.loads(securix.succeed("portail rpc --json list-backends"))[0]['spec'] is not None, "Specification did not get reloaded"
+    securix.wait_for_unit("portail-dynamic-updates.service")
+
+    # Looked up by id, not by list position: list-backends does not guarantee an order.
+    backends = json.loads(securix.succeed("portail rpc --json list-backends"))
+    dyntest = next(b for b in backends if b["id"] == "dyntest")
+    assert dyntest["spec"] is not None, "Specification did not get reloaded"
   '';
 }


### PR DESCRIPTION
Split out of #255.

portail-dynamic-updates.service only starts after portail.service, nothing makes it wait for it to finish, so the test intermittently saw the spec still unset (~1/8 runs on main).

wait_for_unit alone doesn't catch it either, the oneshot exits fast enough that it's usually already inactive by the time it's checked, which wait_for_unit treats as a failure. Added a test-only RemainAfterExit so it stays active after success.