### PR TITLE
http-proxy: gate ssh-tunnel management behind auth.sshForward

### DIFF
--- a/modules/http-proxy/g3proxy/default.nix
+++ b/modules/http-proxy/g3proxy/default.nix
@@ -17,6 +17,7 @@ let
     splitString
     concatMapAttrs
     mapAttrsToList
+    optionalString
     ;
   json = pkgs.formats.json { };
   cfg = config.securix.http-proxy;
@@ -53,9 +54,10 @@ in
             # For connection ID: ${matchConnectionId}
             logger "[Generic proxy hook] Automatically switching to proxy ${proxyToActuate}"
             ${pkgs.proxy-switcher}/bin/proxy-switcher ${proxyToActuate} --cli
-            # TODO: only run this if the auth method uses ssh tunnels.
-            systemctl --user -M "$user"@ stop "ssh-tunnel-to-*" --all
-            systemctl --user -M "$user"@ start ssh-tunnel-to-${proxyToActuate}.service
+            ${optionalString proxyMetadata.auth.sshForward.enable ''
+              systemctl --user -M "$user"@ stop "ssh-tunnel-to-*" --all
+              systemctl --user -M "$user"@ start ssh-tunnel-to-${proxyToActuate}.service
+            ''}
           '';
         };
 
@@ -68,8 +70,9 @@ in
             # For connection ID: ${matchConnectionId}
             logger "[Generic proxy hook] Automatically switching to no proxy"
             ${pkgs.proxy-switcher}/bin/proxy-switcher np
-            # TODO: only run this if the auth method uses ssh tunnels.
-            systemctl --user -M "$user"@ stop "ssh-tunnel-to-${proxyToActuate}.service"
+            ${optionalString proxyMetadata.auth.sshForward.enable ''
+              systemctl --user -M "$user"@ stop "ssh-tunnel-to-${proxyToActuate}.service"
+            ''}
           '';
         };
       }

--- a/modules/http-proxy/portail/default.nix
+++ b/modules/http-proxy/portail/default.nix
@@ -13,6 +13,7 @@ let
     mapAttrsToList
     filterAttrs
     optionalAttrs
+    optionalString
     concatMapAttrs
     ;
   localProxyStream = "127.0.0.1:8080";
@@ -44,10 +45,11 @@ in
             # For connection ID: ${matchConnectionId}
             logger "[Portail proxy hook] Automatically switching to proxy ${proxyToActuate}"
             ${config.services.portail.package}/bin/portail rpc set-default-backend ${proxyToActuate}
-            # TODO: only run this if the auth method uses ssh tunnels.
             # TODO: use Portail's native SSH tunnels later on.
-            systemctl --user -M "$user"@ stop "ssh-tunnel-to-*" --all
-            systemctl --user -M "$user"@ start ssh-tunnel-to-${proxyToActuate}.service
+            ${optionalString proxyMetadata.auth.sshForward.enable ''
+              systemctl --user -M "$user"@ stop "ssh-tunnel-to-*" --all
+              systemctl --user -M "$user"@ start ssh-tunnel-to-${proxyToActuate}.service
+            ''}
           '';
         };
 
@@ -60,9 +62,10 @@ in
             # For connection ID: ${matchConnectionId}
             logger "[Portail proxy hook] Automatically switching to no proxy"
             ${config.services.portail.package}/bin/portail rpc unset-default-backend
-            # TODO: only run this if the auth method uses ssh tunnels.
             # TODO: use Portail's native SSH tunnels later on.
-            systemctl --user -M "$user"@ stop "ssh-tunnel-to-${proxyToActuate}.service"
+            ${optionalString proxyMetadata.auth.sshForward.enable ''
+              systemctl --user -M "$user"@ stop "ssh-tunnel-to-${proxyToActuate}.service"
+            ''}
           '';
         };
       }

--- a/tests/portail.nix
+++ b/tests/portail.nix
@@ -19,6 +19,8 @@ let
               inventoryId = 0;
             };
           };
+
+          networkmanager.events.enable = true;
         };
 
         securix.automatic-http-proxy = {
@@ -31,6 +33,39 @@ let
                 ADDRESS=1.2.3.4
                 PORT=8080
               '';
+            };
+
+            withssh = {
+              vpn = "vpn-a";
+              definition = "static";
+              remote = {
+                address = "1.2.3.4";
+                port = 8080;
+              };
+              auth.sshForward = {
+                enable = true;
+                target = "bastion.example.com";
+              };
+            };
+
+            nossh = {
+              vpn = "vpn-b";
+              definition = "static";
+              remote = {
+                address = "5.6.7.8";
+                port = 8080;
+              };
+            };
+          };
+
+          networkmanager.events.handlers = {
+            withssh = {
+              matchConnectionId = "vpn-a-id";
+              proxyToActuate = "withssh";
+            };
+            nossh = {
+              matchConnectionId = "vpn-b-id";
+              proxyToActuate = "nossh";
             };
           };
         };
@@ -65,5 +100,23 @@ pkgs.testers.nixosTest {
     backends = json.loads(securix.succeed("portail rpc --json list-backends"))
     dyntest = next(b for b in backends if b["id"] == "dyntest")
     assert dyntest["spec"] is not None, "Specification did not get reloaded"
+
+    dispatcher = securix.succeed(
+      "grep -rl securix-nm-events-hook /etc/NetworkManager/dispatcher.d/"
+    ).strip()
+    content = securix.succeed(f"cat {dispatcher}")
+
+    assert "start ssh-tunnel-to-withssh.service" in content, (
+      "vpn-up: expected the withssh proxy (auth.sshForward.enable) to manage its ssh-tunnel unit"
+    )
+    assert 'stop "ssh-tunnel-to-withssh.service"' in content, (
+      "vpn-down: expected the withssh proxy (auth.sshForward.enable) to stop its ssh-tunnel unit"
+    )
+    assert "start ssh-tunnel-to-nossh.service" not in content, (
+      "vpn-up: the nossh proxy has no auth.sshForward, it must not try to start a ssh-tunnel unit that is never generated for it"
+    )
+    assert 'stop "ssh-tunnel-to-nossh.service"' not in content, (
+      "vpn-down: the nossh proxy has no auth.sshForward, it must not try to stop a ssh-tunnel unit that is never generated for it"
+    )
   '';
 }


### PR DESCRIPTION
Both g3proxy and portail ran systemctl ... ssh-tunnel-to-* on every proxy switch, even without auth.sshForward. Gated it behind proxyMetadata.auth.sshForward.enable.

Added withssh/nossh proxies to tests/portail.nix