### PR TITLE
feat(installer): ask for the target disk when the configured one is missing

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -261,7 +261,8 @@ rec {
               This is the Securix live offline installer image edition ${edition}.
 
               This installer will install your system in ${mainDisk}, if that's not what you want,
-              contact the system administrators.
+              contact the system administrators. If that disk is missing, the installer will ask
+              which disk to use instead.
 
               Run: `autoinstall-terminal` to start the automatic installation process.
             '';
@@ -366,11 +367,35 @@ rec {
 
                         box_message "All preflight checks passed."
 
-                        log_info "${mainDisk} will be re-initialized and formatted, please confirm this is the right target."
+                        main_disk="${mainDisk}"
+                        if [ ! -b "$main_disk" ]; then
+                          log_warn "$main_disk does not exist on this machine."
+                          candidates=()
+                          while read -r name size type model; do
+                            [ "$type" = "disk" ] || continue
+                            # Skip the disks in use, such as the installer medium.
+                            if lsblk -no MOUNTPOINTS "/dev/$name" | grep -q .; then
+                              continue
+                            fi
+                            candidates+=("/dev/$name $size $model")
+                          done < <(lsblk -dn -o NAME,SIZE,TYPE,MODEL -e 2,7,11)
+                          if [ "''${#candidates[@]}" -eq 0 ]; then
+                            log_error "No disk available for the installation."
+                            exit 1
+                          fi
+                          choice=$(${pkgs.gum}/bin/gum choose --header "Installation disk" "''${candidates[@]}") || { log_warn "Operation cancelled."; exit 0; }
+                          main_disk="''${choice%% *}"
+                          # The partitioning scripts only know the configured path, so point it at the chosen disk.
+                          mkdir -p "$(dirname "${mainDisk}")"
+                          ln -s "$main_disk" "${mainDisk}"
+                          log_info "${mainDisk} now points to $main_disk."
+                        fi
+
+                        log_info "$main_disk will be re-initialized and formatted, please confirm this is the right target."
                         ${pkgs.gum}/bin/gum confirm "Proceed with reformatting?" || { log_warn "Operation cancelled."; exit 0; }
 
-                        wipefs -fa "${mainDisk}" ; sudo dd if=/dev/zero of="${mainDisk}" bs=4M count=1024;
-                        log_info "${mainDisk} re-initialized and formatted."
+                        wipefs -fa "$main_disk" ; sudo dd if=/dev/zero of="$main_disk" bs=4M count=1024;
+                        log_info "$main_disk re-initialized and formatted."
 
                         ${pkgs.systemd}/bin/udevadm settle
                         ${diskProcedureScript}
@@ -383,7 +408,7 @@ rec {
                           exit 1
                         fi
                         ${optionalString createSecureBootKeys createSecureBootKeysScript}
-                        box_message "Burning the image on ${mainDisk}..."
+                        box_message "Burning the image on $main_disk..."
                         ${installProcedureScript config}
                         ${optionalString enrollSecureBootKeys secureBootEnrollmentScript}
                         ${optionalString (preprovisionOptions.tpm2HostKeys or false) tpm2ProvisionScript}

--- a/tests/autoinstall-missing-disk.nix
+++ b/tests/autoinstall-missing-disk.nix
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2026 Quentin Cazier <cazierquentin@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# Regression test for https://github.com/cloud-gouv/securix/issues/131
+#
+# Boots a Securix installer whose configured disk does not exist, picks the
+# disk offered by `autoinstall-terminal` and checks that the installation
+# lands on it. A second run must not ask again.
+
+{ pkgs, libSecurix }:
+
+let
+  lib = pkgs.lib;
+
+  targetSystem = pkgs.nixos (
+    { lib, ... }: {
+      imports = [ "${pkgs.disko.src}/module.nix" ];
+
+      options.securix.self.mainDisk = lib.mkOption { type = lib.types.str; };
+
+      config = {
+        securix.self.mainDisk = "/dev/nvme0n1";
+
+        disko.devices.disk.main = {
+          device = "/dev/nvme0n1";
+          type = "disk";
+          content = {
+            type = "gpt";
+            partitions.root = {
+              size = "100%";
+              content = {
+                type = "luks";
+                name = "securix-root";
+                passwordFile = "/tmp/disk-passphrase";
+                content = {
+                  type = "filesystem";
+                  format = "ext4";
+                  mountpoint = "/";
+                };
+              };
+            };
+          };
+        };
+
+        users.users.root.initialPassword = "test";
+        fileSystems."/".device = "/dev/mapper/securix-root";
+        fileSystems."/".fsType = "ext4";
+        boot.loader.grub.enable = false;
+      };
+    }
+  );
+
+  installer = libSecurix.buildInstallerSystem {
+    inherit targetSystem;
+    installScript = "echo 'install skipped for test'";
+    preprovisionOptions = {
+      secureBoot = "disabled";
+      skipPreflightCheck = true;
+      tpm2HostKeys = false;
+      ageHostKeys = false;
+    };
+  };
+
+  autoinstallPkg =
+    lib.findFirst (p: p.name or "" == "autoinstall-terminal")
+      (throw "autoinstall-terminal not found in installer packages")
+      installer.config.environment.systemPackages;
+
+in
+pkgs.testers.nixosTest {
+  name = "autoinstall-terminal-missing-disk";
+
+  nodes.machine = _: {
+    virtualisation.emptyDiskImages = [ 4096 ];
+    environment.systemPackages = [
+      autoinstallPkg
+      pkgs.expect
+    ];
+  };
+
+  testScript = ''
+    import textwrap
+
+    first_run = textwrap.dedent("""\
+        expect <<'EXPECT_EOF'
+        set timeout 300
+        spawn autoinstall-terminal
+        expect "Installation disk"
+        sleep 1
+        send "\r"
+        expect "Proceed with reformatting?"
+        send "\r"
+        expect {
+            "Installation is complete" { exit 0 }
+            timeout { puts "TIMEOUT"; exit 1 }
+            eof { puts "UNEXPECTED EOF"; exit 1 }
+        }
+        EXPECT_EOF
+    """)
+
+    second_run = textwrap.dedent("""\
+        expect <<'EXPECT_EOF'
+        set timeout 300
+        spawn autoinstall-terminal
+        expect {
+            "Installation disk" { puts "ASKED AGAIN"; exit 1 }
+            "Proceed with reformatting?" { send "\r" }
+            timeout { puts "TIMEOUT"; exit 1 }
+            eof { puts "UNEXPECTED EOF"; exit 1 }
+        }
+        expect {
+            "Installation is complete" { exit 0 }
+            timeout { puts "TIMEOUT"; exit 1 }
+            eof { puts "UNEXPECTED EOF"; exit 1 }
+        }
+        EXPECT_EOF
+    """)
+
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("echo -n 'testpassphrase' > /tmp/disk-passphrase")
+    machine.fail("test -e /dev/nvme0n1")
+
+    machine.succeed(first_run)
+    machine.succeed("test \"$(readlink /dev/nvme0n1)\" = /dev/vdb")
+    machine.succeed("lsblk -no PARTLABEL /dev/vdb | grep -q disk-main-root")
+
+    machine.succeed(second_run)
+  '';
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,6 +7,7 @@
   minimal = import ./minimal.nix { inherit pkgs libSecurix; };
   anssi-minimal = import ./anssi-minimal.nix { inherit pkgs libSecurix; };
   idempotent-autoinstall = import ./idempotent-autoinstall.nix { inherit pkgs libSecurix; };
+  autoinstall-missing-disk = import ./autoinstall-missing-disk.nix { inherit pkgs libSecurix; };
   portail = import ./portail.nix { inherit pkgs libSecurix; };
   tools = import ./tools.nix { inherit pkgs libSecurix; };
 }


### PR DESCRIPTION
Closes #131

When `securix.self.mainDisk` does not exist on the machine, `autoinstall-terminal` used to run `wipefs` and the disko format script on a missing path and fail, which meant rebuilding the ISO with the right disk.

The installer now checks the configured disk before anything is written. When it is missing, it lists the disks that are not in use (floppy, loop and optical devices are excluded, as well as any disk holding a mounted filesystem such as the installer medium), asks which one to use with `gum choose`, and creates a symlink from the configured path to the chosen disk. The disko scripts then run unchanged: they only use the disk path for partitioning and address the partitions by label, so the installed system and the partition labels are the same as with a matching configuration. The filesystem layouts and existing installations are not touched.

When the configured disk exists, nothing changes.

## Test

`tests/autoinstall-missing-disk.nix` boots an installer configured for `/dev/nvme0n1` in a VM that only has `/dev/vdb`, answers the prompt, and checks that `/dev/nvme0n1` points to `/dev/vdb`, that the partitions were created there, and that a second run does not ask again. `tests/idempotent-autoinstall.nix` still passes.
